### PR TITLE
Bug Fix: track emergency basket changes for a new proposal

### DIFF
--- a/src/views/governance/views/proposal/hooks/useProposalTx.ts
+++ b/src/views/governance/views/proposal/hooks/useProposalTx.ts
@@ -349,7 +349,7 @@ const useProposalTx = () => {
       ## Parse backup            ## 
       ############################# */
       if (newBackup && backupChanges.count) {
-        for (const targetUnit of Object.keys(newBackup)) {
+        for (const targetUnit of Object.keys(backup)) {
           const { collaterals, diversityFactor } = backup[targetUnit]
 
           const backupCollaterals: Address[] = []


### PR DESCRIPTION
In the original code, `newBackup` was mistakenly used and it's a boolean, which is not suitable for `Object.keys()`. Changing it to `backup`, which is an object, fixed the issue, allowing the proposal to correctly process changes in the emergency basket.