### PR TITLE
Fix fusdc naming and stRSR methodology

### DIFF
--- a/src/hooks/useTokenStats.tsx
+++ b/src/hooks/useTokenStats.tsx
@@ -62,7 +62,7 @@ const useTokenStats = (rTokenId: string, isRSV = false): TokenStats => {
   const rTokenPrice = useAtomValue(rTokenPriceAtom)
 
   useEffect(() => {
-    if (data?.rtoken || data?.token) {
+    if ((data?.rtoken || data?.token) && stTokenSupply && exchangeRate) {
       const staked = stTokenSupply * exchangeRate ?? '0'
       const supply = +formatEther(data?.token.totalSupply)
       const cumulativeVolume = +formatEther(data?.token.cumulativeVolume)
@@ -114,7 +114,13 @@ const useTokenStats = (rTokenId: string, isRSV = false): TokenStats => {
       setLastFetched(rTokenId)
       setStats(tokenData)
     }
-  }, [JSON.stringify(data), rTokenPrice, rpayOverview])
+  }, [
+    JSON.stringify(data),
+    rTokenPrice,
+    rpayOverview,
+    stTokenSupply,
+    exchangeRate,
+  ])
 
   useEffect(() => {
     if (rTokenId !== lastFetched) {

--- a/src/hooks/useTokenStats.tsx
+++ b/src/hooks/useTokenStats.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react'
 import {
   chainIdAtom,
   rTokenPriceAtom,
+  rTokenStateAtom,
   rpayOverviewAtom,
   rsrPriceAtom,
 } from 'state/atoms'
@@ -50,6 +51,7 @@ const useTokenStats = (rTokenId: string, isRSV = false): TokenStats => {
   const fromTime = useTimeFrom(TIME_RANGES.DAY)
   const chainId = useAtomValue(chainIdAtom)
   const [lastFetched, setLastFetched] = useAtom(lastFetchedStatsAtom)
+  const { stTokenSupply, exchangeRate } = useAtomValue(rTokenStateAtom)
 
   const { data } = useQuery(rTokenMetricsQuery, {
     id: rTokenId,
@@ -61,7 +63,7 @@ const useTokenStats = (rTokenId: string, isRSV = false): TokenStats => {
 
   useEffect(() => {
     if (data?.rtoken || data?.token) {
-      const staked = +formatEther(data?.rtoken?.rsrStaked ?? '0')
+      const staked = stTokenSupply * exchangeRate ?? '0'
       const supply = +formatEther(data?.token.totalSupply)
       const cumulativeVolume = +formatEther(data?.token.cumulativeVolume)
       const dailyVolume = +formatEther(

--- a/src/state/updaters/CollateralYieldUpdater.tsx
+++ b/src/state/updaters/CollateralYieldUpdater.tsx
@@ -16,7 +16,7 @@ const poolsMap: StringMap = {
   '6c2b7a5c-6c4f-49ea-a08c-0366b772f2c2': 'cusdp',
   '1d876729-4445-4623-8b6b-c5290db5d100': 'cwbtc',
   '1e5da7c6-59bb-49bd-9f97-4f4fceeffad4': 'ceth',
-  'fa4d7ee4-0001-4133-9e8d-cf7d5d194a91': 'fusdc-vault',
+  'fa4d7ee4-0001-4133-9e8d-cf7d5d194a91': 'fusdc',
   'ed227286-abb0-4a34-ada5-39f7ebd81afb': 'fdai',
   '6600934f-6323-447d-8a7d-67fbede8529d': 'fusdt',
   '747c1d2a-c668-4682-b9f9-296708a3dd90': 'wsteth',


### PR DESCRIPTION
1. Current fUSDC is not displaying APR 
![image](https://github.com/reserve-protocol/register/assets/71284258/e903089e-81f0-44e7-89e3-6ccaaa56dc74)

2. Stake pool shows total RSR in the contract, including pending RSR rewards and pending withdrawals. This does not allow people to accurately work backwards to get the stRSR yield. I suggest displaying the lower number here 
![image](https://github.com/reserve-protocol/register/assets/71284258/4ee20b25-29c1-40da-b86b-f2d2eba8c01a)