### PR TITLE
Bugfix: fix revenue fields in the deployment form

### DIFF
--- a/src/components/rtoken-setup/token/ExternalRevenueSplit.tsx
+++ b/src/components/rtoken-setup/token/ExternalRevenueSplit.tsx
@@ -90,7 +90,7 @@ const ExternalRevenueSpit = ({
           </Field>
           <Field label={t`As RToken`}>
             <FieldInput
-              {...register('holders', { ...inputValidation, min: 10 })}
+              {...register('holders', { ...inputValidation, min: 0 })}
               error={!!errors['holders']}
               sx={{
                 borderRadius: '0',
@@ -100,7 +100,7 @@ const ExternalRevenueSpit = ({
           </Field>
           <Field label={t`As RSR`}>
             <FieldInput
-              {...register('stakers', { ...inputValidation, min: 10 })}
+              {...register('stakers', { ...inputValidation, min: 0 })}
               error={!!errors['stakers']}
               sx={{
                 borderRadius: '0 6px 0 0',


### PR DESCRIPTION
Now:
<img width="1222" alt="Screenshot 2024-01-11 at 10 04 42" src="https://github.com/reserve-protocol/register/assets/11811232/a9b940c8-e510-43fe-a129-14b26eb9067f">
