### PR TITLE
Manually set era on hyusd (base) so withdrawal cooldowns are shown

### DIFF
--- a/src/views/staking/Updater.tsx
+++ b/src/views/staking/Updater.tsx
@@ -1,23 +1,26 @@
 import FacadeRead from 'abis/FacadeRead'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 import { chainIdAtom, rTokenAtom, walletAtom } from 'state/atoms'
 import { FACADE_ADDRESS } from 'utils/addresses'
 import { useContractRead } from 'wagmi'
 import { formatEther } from 'viem'
-import { pendingRSRAtom } from './atoms'
+import { pendingRSRAtom, pendingRSRManualAtom } from './atoms'
 
 /**
  * Fetch pending issuances
  */
 // TODO: Move this to an loadable atom
+
+// TODO: Revert manual overrides once 3.2.0 released
 const PendingBalancesUpdater = () => {
   const account = useAtomValue(walletAtom)
   const chainId = useAtomValue(chainIdAtom)
   const rToken = useAtomValue(rTokenAtom)
+  const pendingRSRManual = useAtomValue(pendingRSRManualAtom)
   const setPendingRSR = useSetAtom(pendingRSRAtom)
 
-  const { data } = useContractRead(
+  let { data } = useContractRead(
     rToken && account
       ? {
           abi: FacadeRead,
@@ -28,6 +31,13 @@ const PendingBalancesUpdater = () => {
         }
       : undefined
   )
+
+  if (
+    rToken?.address.toLowerCase() ===
+    '0xcc7ff230365bd730ee4b352cc2492cedac49383e'
+  ) {
+    data = pendingRSRManual
+  }
 
   useEffect(() => {
     if (data) {

--- a/src/views/staking/Updater.tsx
+++ b/src/views/staking/Updater.tsx
@@ -12,32 +12,28 @@ import { pendingRSRAtom, pendingRSRManualAtom } from './atoms'
  */
 // TODO: Move this to an loadable atom
 
-// TODO: Revert manual overrides once 3.2.0 released
+// TODO: Remove pendingRSRManualAtom (and use FacadeRead) once 3.2.0 released
 const PendingBalancesUpdater = () => {
   const account = useAtomValue(walletAtom)
   const chainId = useAtomValue(chainIdAtom)
   const rToken = useAtomValue(rTokenAtom)
+
   const pendingRSRManual = useAtomValue(pendingRSRManualAtom)
   const setPendingRSR = useSetAtom(pendingRSRAtom)
 
-  let { data } = useContractRead(
-    rToken && account
-      ? {
-          abi: FacadeRead,
-          address: FACADE_ADDRESS[chainId],
-          functionName: 'pendingUnstakings',
-          args: [rToken?.address, account],
-          chainId,
-        }
-      : undefined
-  )
+  // let { data } = useContractRead(
+  //   rToken && account
+  //     ? {
+  //         abi: FacadeRead,
+  //         address: FACADE_ADDRESS[chainId],
+  //         functionName: 'pendingUnstakings',
+  //         args: [rToken?.address, account],
+  //         chainId,
+  //       }
+  //     : undefined
+  // )
 
-  if (
-    rToken?.address.toLowerCase() ===
-    '0xcc7ff230365bd730ee4b352cc2492cedac49383e'
-  ) {
-    data = pendingRSRManual
-  }
+  const data = pendingRSRManual
 
   useEffect(() => {
     if (data) {


### PR DESCRIPTION
On Base hyUSD, because RSR was seized, the `draftEra` in stRSR was incremented.  `FacadeRead` relies on `era`, which results in users not being able to see their pending RSR withdrawals. This is a minor protocol bug.

The solution for now is to manually query the storage slot of `draftEra` so that it can continue to function, until 3.2.0 is released with a `FacadeRead` that corrects this, **at which point this patch should be removed**

See left (with patch) vs right (production) 
<img width="1205" alt="image" src="https://github.com/reserve-protocol/register/assets/71284258/a26cb9c2-5715-4436-ae2b-418595124a6c">

Tested with impersonated wallets having pending withdrawals on hyUSD (Base), eUSD, USDC+