### PR TITLE
Feature: Guardian functionality

### DIFF
--- a/src/views/governance/components/ProposalList.tsx
+++ b/src/views/governance/components/ProposalList.tsx
@@ -42,6 +42,7 @@ const BADGE_VARIANT: StringMap = {
   [PROPOSAL_STATES.QUORUM_NOT_REACHED]: 'danger',
   [PROPOSAL_STATES.ACTIVE]: 'info',
   [PROPOSAL_STATES.EXECUTED]: 'success',
+  [PROPOSAL_STATES.CANCELED]: 'danger',
 }
 
 const useProposals = () => {

--- a/src/views/governance/views/proposal-detail/atom.ts
+++ b/src/views/governance/views/proposal-detail/atom.ts
@@ -185,6 +185,17 @@ export const timelockIdAtom = atom((get) => {
   return encodedParams ? keccak256(encodedParams) : undefined;
 })
 
+export const canExecuteAtom = atom((get) => {
+  const proposal = get(proposalDetailAtom)
+  const blockNumber = get(blockAtom)
+
+  return (
+    blockNumber &&
+    proposal?.executionStartBlock &&
+    proposal?.executionStartBlock <= blockNumber
+  )
+})
+
 export const simulationStateAtom = atomWithReset<SimulationState>({
   data: null,
   loading: false,

--- a/src/views/governance/views/proposal-detail/atom.ts
+++ b/src/views/governance/views/proposal-detail/atom.ts
@@ -1,7 +1,7 @@
 import { PROPOSAL_STATES, blockDuration } from 'utils/constants'
 import { atom } from 'jotai'
 import { blockAtom, chainIdAtom, rTokenGovernanceAtom } from 'state/atoms'
-import { Address, Hex, keccak256, parseEther, toBytes } from 'viem'
+import { Address, Hex, encodeAbiParameters, keccak256, parseAbiParameters, parseEther, toBytes } from 'viem'
 import { TenderlySimulation } from 'types'
 import { atomWithReset } from 'jotai/utils'
 
@@ -169,6 +169,21 @@ export const proposalTxArgsAtom = atom(
     ]
   }
 )
+
+export const timelockIdAtom = atom((get) => {
+  const proposal = get(proposalDetailAtom)
+
+  const encodedParams = proposal ?
+    encodeAbiParameters(parseAbiParameters('address[], uint256[], bytes[], bytes32, bytes32'), [
+      proposal.targets,
+      [0n],
+      proposal.calldatas,
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+      keccak256(toBytes(proposal.description)),
+    ]) : undefined
+
+  return encodedParams ? keccak256(encodedParams) : undefined;
+})
 
 export const simulationStateAtom = atomWithReset<SimulationState>({
   data: null,

--- a/src/views/governance/views/proposal-detail/components/ProposalCancel.tsx
+++ b/src/views/governance/views/proposal-detail/components/ProposalCancel.tsx
@@ -5,14 +5,13 @@ import useContractWrite from 'hooks/useContractWrite'
 import useWatchTransaction from 'hooks/useWatchTransaction'
 import { useAtomValue } from 'jotai'
 import { rTokenGovernanceAtom, walletAtom } from 'state/atoms'
-import { canExecuteAtom, timelockIdAtom } from '../atom'
+import { timelockIdAtom } from '../atom'
 import { useContractRead } from 'wagmi'
 import { keccak256, toBytes } from 'viem'
 
 const ProposalCancel = () => {
   const governance = useAtomValue(rTokenGovernanceAtom)
   const timelockId = useAtomValue(timelockIdAtom);
-  const canExecute = useAtomValue(canExecuteAtom);
   const account = useAtomValue(walletAtom)
 
   const { data: canCancel } = useContractRead({
@@ -43,10 +42,10 @@ const ProposalCancel = () => {
 
   return (
     <TransactionButton
+      variant='danger'
       small
       loading={isMining || isLoading}
       mining={isMining}
-      ml={canExecute ? 1 : 'auto'}
       disabled={!isReady}
       onClick={write}
       text={t`Cancel proposal`}

--- a/src/views/governance/views/proposal-detail/components/ProposalCancel.tsx
+++ b/src/views/governance/views/proposal-detail/components/ProposalCancel.tsx
@@ -1,0 +1,39 @@
+import { t } from '@lingui/macro'
+import Timelock from 'abis/Timelock'
+import TransactionButton from 'components/button/TransactionButton'
+import useContractWrite from 'hooks/useContractWrite'
+import useWatchTransaction from 'hooks/useWatchTransaction'
+import { useAtomValue } from 'jotai'
+import { rTokenGovernanceAtom } from 'state/atoms'
+import { timelockIdAtom } from '../atom'
+
+const ProposalCancel = () => {
+  const governance = useAtomValue(rTokenGovernanceAtom)
+  const timelockId = useAtomValue(timelockIdAtom);
+
+  const { write, isLoading, hash, isReady } = useContractWrite({
+    abi: Timelock,
+    address: governance?.timelock,
+    functionName: 'cancel',
+    args: timelockId ? [timelockId] : undefined,
+  })
+
+  const { isMining } = useWatchTransaction({
+    hash,
+    label: 'Proposal canceled',
+  })
+
+  return (
+    <TransactionButton
+      small
+      loading={isMining || isLoading}
+      mining={isMining}
+      ml={1}
+      disabled={!isReady}
+      onClick={write}
+      text={t`Cancel proposal`}
+    />
+  )
+}
+
+export default ProposalCancel

--- a/src/views/governance/views/proposal-detail/components/ProposalCancel.tsx
+++ b/src/views/governance/views/proposal-detail/components/ProposalCancel.tsx
@@ -5,11 +5,18 @@ import useContractWrite from 'hooks/useContractWrite'
 import useWatchTransaction from 'hooks/useWatchTransaction'
 import { useAtomValue } from 'jotai'
 import { rTokenGovernanceAtom } from 'state/atoms'
-import { timelockIdAtom } from '../atom'
+import { canExecuteAtom, timelockIdAtom } from '../atom'
 
 const ProposalCancel = () => {
   const governance = useAtomValue(rTokenGovernanceAtom)
   const timelockId = useAtomValue(timelockIdAtom);
+  const canExecute = useAtomValue(canExecuteAtom);
+
+  const canCancel = false
+
+  if (!canCancel) {
+    return null
+  }
 
   const { write, isLoading, hash, isReady } = useContractWrite({
     abi: Timelock,
@@ -28,7 +35,7 @@ const ProposalCancel = () => {
       small
       loading={isMining || isLoading}
       mining={isMining}
-      ml={1}
+      ml={canExecute ? 1 : 'auto'}
       disabled={!isReady}
       onClick={write}
       text={t`Cancel proposal`}

--- a/src/views/governance/views/proposal-detail/components/ProposalExecute.tsx
+++ b/src/views/governance/views/proposal-detail/components/ProposalExecute.tsx
@@ -34,7 +34,6 @@ const ProposalExecute = () => {
       small
       loading={isMining || isLoading}
       mining={isMining}
-      ml="auto"
       disabled={!isReady}
       onClick={write}
       text={t`Execute proposal`}

--- a/src/views/governance/views/proposal-detail/components/ProposalExecute.tsx
+++ b/src/views/governance/views/proposal-detail/components/ProposalExecute.tsx
@@ -4,17 +4,12 @@ import TransactionButton from 'components/button/TransactionButton'
 import useContractWrite from 'hooks/useContractWrite'
 import useWatchTransaction from 'hooks/useWatchTransaction'
 import { useAtomValue } from 'jotai'
-import { blockAtom, rTokenGovernanceAtom } from 'state/atoms'
-import { proposalDetailAtom, proposalTxArgsAtom } from '../atom'
+import { rTokenGovernanceAtom } from 'state/atoms'
+import { canExecuteAtom, proposalTxArgsAtom } from '../atom'
 
 const ProposalExecute = () => {
-  const blockNumber = useAtomValue(blockAtom)
   const governance = useAtomValue(rTokenGovernanceAtom)
-  const proposal = useAtomValue(proposalDetailAtom)
-  const canExecute =
-    blockNumber &&
-    proposal?.executionStartBlock &&
-    proposal?.executionStartBlock <= blockNumber
+  const canExecute = useAtomValue(canExecuteAtom)
 
   const { write, isLoading, hash, isReady } = useContractWrite({
     abi: Governance,

--- a/src/views/governance/views/proposal-detail/index.tsx
+++ b/src/views/governance/views/proposal-detail/index.tsx
@@ -26,6 +26,7 @@ import ProposalVotes from './components/ProposalVotes'
 import useProposalDetail from './useProposalDetail'
 import ExternalArrowIcon from 'components/icons/ExternalArrowIcon'
 import { ExplorerDataType, getExplorerLink } from 'utils/getExplorerLink'
+import ProposalCancel from './components/ProposalCancel'
 
 const GovernanceProposalDetail = () => {
   const { proposalId } = useParams()
@@ -102,6 +103,7 @@ const GovernanceProposalDetail = () => {
         <ProposalAlert />
         {state === PROPOSAL_STATES.SUCCEEDED && <ProposalQueue />}
         {state === PROPOSAL_STATES.QUEUED && <ProposalExecute />}
+        {state === PROPOSAL_STATES.QUEUED && <ProposalCancel />}
         {!!proposal?.executionTxnHash && (
           <Button
             small

--- a/src/views/governance/views/proposal-detail/index.tsx
+++ b/src/views/governance/views/proposal-detail/index.tsx
@@ -102,8 +102,19 @@ const GovernanceProposalDetail = () => {
         </SmallButton>
         <ProposalAlert />
         {state === PROPOSAL_STATES.SUCCEEDED && <ProposalQueue />}
-        {state === PROPOSAL_STATES.QUEUED && <ProposalExecute />}
-        {state === PROPOSAL_STATES.QUEUED && <ProposalCancel />}
+        {state === PROPOSAL_STATES.QUEUED && (
+          <Box
+            variant="layout.verticalAlign"
+            sx={{
+              ml: 'auto',
+              gap: 3,
+              ":not(:has(> *))": { ml: 0 }
+            }}
+          >
+            <ProposalCancel />
+            <ProposalExecute />
+          </Box>
+        )}
         {!!proposal?.executionTxnHash && (
           <Button
             small


### PR DESCRIPTION
- Guardian has the ability to cancel a queued tx in the timelock
<img width="1470" alt="Screenshot 2024-01-18 at 14 19 28" src="https://github.com/reserve-protocol/register/assets/11811232/8a264a1a-e40c-4875-89fa-6a55ea4f6f4e">

- Any proposal that has been “canceled” should reflect that in the UI
<img width="813" alt="Screenshot 2024-01-18 at 12 17 11" src="https://github.com/reserve-protocol/register/assets/11811232/af56cfe5-310a-4634-903b-a7161121a643">  

Changes in the subgraph: https://github.com/reserve-protocol/reserve-subgraph/pull/5