### PR TITLE
Zapper bugfixes round 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@popperjs/core": "^2.11.5",
         "@rainbow-me/rainbowkit": "1.3.0",
         "@react-spring/web": "^9.7.1",
-        "@reserve-protocol/token-zapper": "3.0.5",
+        "@reserve-protocol/token-zapper": "3.0.6",
         "@tanstack/react-table": "^8.10.7",
         "@uiw/react-md-editor": "^3.20.5",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -5290,9 +5290,9 @@
       }
     },
     "node_modules/@reserve-protocol/token-zapper": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@reserve-protocol/token-zapper/-/token-zapper-3.0.5.tgz",
-      "integrity": "sha512-O1EbPZn+CF+faIharPO7HdbvjtWTWF7Z2LjTm8YUEI2HVPkkLlPhsv5xVPG6WVX3X1GXEGjN314gA18duQaEsA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@reserve-protocol/token-zapper/-/token-zapper-3.0.6.tgz",
+      "integrity": "sha512-+ccsZNNu6hbXTGXkw4Cu6vOKQ6ar6XEmAqjDtmpMzb3xQEOOXDOMw196DO8wa31xQdjOmkW67Tta/kt5ET/e6Q==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/providers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@popperjs/core": "^2.11.5",
     "@rainbow-me/rainbowkit": "1.3.0",
     "@react-spring/web": "^9.7.1",
-    "@reserve-protocol/token-zapper": "3.0.5",
+    "@reserve-protocol/token-zapper": "3.0.6",
     "@tanstack/react-table": "^8.10.7",
     "@uiw/react-md-editor": "^3.20.5",
     "@uniswap/permit2-sdk": "^1.2.0",


### PR DESCRIPTION
This PR fixes a bug in the zapper that caused instability in production.

The bug was caused by the zapper searching both zap by issueance and zap by trade. Expected behavior was for zap to be returned as long as one of them produced a result. But the bug caused the zapper to always recalculate both paths even if there is no way to trade into an RToken.

