### PR TITLE
Conform to Facade Read Interface

### DIFF
--- a/src/abis/FacadeRead.ts
+++ b/src/abis/FacadeRead.ts
@@ -1,43 +1,23 @@
 export default [
-  {
-    inputs: [],
-    name: 'UIntOutOfBounds',
-    type: 'error',
-  },
+  { inputs: [], name: 'UIntOutOfBounds', type: 'error' },
   {
     inputs: [
-      {
-        internalType: 'contract ITrading',
-        name: 'trader',
-        type: 'address',
-      },
+      { internalType: 'contract ITrading', name: 'trader', type: 'address' },
     ],
     name: 'auctionsSettleable',
     outputs: [
-      {
-        internalType: 'contract IERC20[]',
-        name: 'erc20s',
-        type: 'address[]',
-      },
+      { internalType: 'contract IERC20[]', name: 'erc20s', type: 'address[]' },
     ],
     stateMutability: 'view',
     type: 'function',
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
     ],
     name: 'backingOverview',
     outputs: [
-      {
-        internalType: 'uint192',
-        name: 'backing',
-        type: 'uint192',
-      },
+      { internalType: 'uint192', name: 'backing', type: 'uint192' },
       {
         internalType: 'uint192',
         name: 'overCollateralization',
@@ -49,53 +29,25 @@ export default [
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
-      {
-        internalType: 'bytes32',
-        name: 'targetName',
-        type: 'bytes32',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
+      { internalType: 'bytes32', name: 'targetName', type: 'bytes32' },
     ],
     name: 'backupConfig',
     outputs: [
-      {
-        internalType: 'contract IERC20[]',
-        name: 'erc20s',
-        type: 'address[]',
-      },
-      {
-        internalType: 'uint256',
-        name: 'max',
-        type: 'uint256',
-      },
+      { internalType: 'contract IERC20[]', name: 'erc20s', type: 'address[]' },
+      { internalType: 'uint256', name: 'max', type: 'uint256' },
     ],
     stateMutability: 'view',
     type: 'function',
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
     ],
     name: 'balancesAcrossAllTraders',
     outputs: [
-      {
-        internalType: 'contract IERC20[]',
-        name: 'erc20s',
-        type: 'address[]',
-      },
-      {
-        internalType: 'uint256[]',
-        name: 'balances',
-        type: 'uint256[]',
-      },
+      { internalType: 'contract IERC20[]', name: 'erc20s', type: 'address[]' },
+      { internalType: 'uint256[]', name: 'balances', type: 'uint256[]' },
       {
         internalType: 'uint256[]',
         name: 'balancesNeededByBackingManager',
@@ -107,142 +59,63 @@ export default [
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
     ],
     name: 'basketBreakdown',
     outputs: [
-      {
-        internalType: 'address[]',
-        name: 'erc20s',
-        type: 'address[]',
-      },
-      {
-        internalType: 'uint192[]',
-        name: 'uoaShares',
-        type: 'uint192[]',
-      },
-      {
-        internalType: 'bytes32[]',
-        name: 'targets',
-        type: 'bytes32[]',
-      },
+      { internalType: 'address[]', name: 'erc20s', type: 'address[]' },
+      { internalType: 'uint192[]', name: 'uoaShares', type: 'uint192[]' },
+      { internalType: 'bytes32[]', name: 'targets', type: 'bytes32[]' },
     ],
     stateMutability: 'nonpayable',
     type: 'function',
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
     ],
     name: 'basketTokens',
-    outputs: [
-      {
-        internalType: 'address[]',
-        name: 'tokens',
-        type: 'address[]',
-      },
-    ],
+    outputs: [{ internalType: 'address[]', name: 'tokens', type: 'address[]' }],
     stateMutability: 'view',
     type: 'function',
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
-      {
-        internalType: 'uint256',
-        name: 'amount',
-        type: 'uint256',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
+      { internalType: 'uint256', name: 'amount', type: 'uint256' },
     ],
     name: 'issue',
     outputs: [
-      {
-        internalType: 'address[]',
-        name: 'tokens',
-        type: 'address[]',
-      },
-      {
-        internalType: 'uint256[]',
-        name: 'deposits',
-        type: 'uint256[]',
-      },
-      {
-        internalType: 'uint192[]',
-        name: 'depositsUoA',
-        type: 'uint192[]',
-      },
+      { internalType: 'address[]', name: 'tokens', type: 'address[]' },
+      { internalType: 'uint256[]', name: 'deposits', type: 'uint256[]' },
+      { internalType: 'uint192[]', name: 'depositsUoA', type: 'uint192[]' },
     ],
     stateMutability: 'nonpayable',
     type: 'function',
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
-      {
-        internalType: 'address',
-        name: 'account',
-        type: 'address',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
+      { internalType: 'address', name: 'account', type: 'address' },
     ],
     name: 'maxIssuable',
-    outputs: [
-      {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256',
-      },
-    ],
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
     stateMutability: 'nonpayable',
     type: 'function',
   },
   {
     inputs: [
-      {
-        internalType: 'contract RTokenP1',
-        name: 'rToken',
-        type: 'address',
-      },
-      {
-        internalType: 'address',
-        name: 'account',
-        type: 'address',
-      },
+      { internalType: 'contract RTokenP1', name: 'rToken', type: 'address' },
+      { internalType: 'uint256', name: 'draftEra', type: 'uint256' },
+      { internalType: 'address', name: 'account', type: 'address' },
     ],
     name: 'pendingUnstakings',
     outputs: [
       {
         components: [
-          {
-            internalType: 'uint256',
-            name: 'index',
-            type: 'uint256',
-          },
-          {
-            internalType: 'uint256',
-            name: 'availableAt',
-            type: 'uint256',
-          },
-          {
-            internalType: 'uint256',
-            name: 'amount',
-            type: 'uint256',
-          },
+          { internalType: 'uint256', name: 'index', type: 'uint256' },
+          { internalType: 'uint256', name: 'availableAt', type: 'uint256' },
+          { internalType: 'uint256', name: 'amount', type: 'uint256' },
         ],
         internalType: 'struct IFacadeRead.Pending[]',
         name: 'unstakings',
@@ -254,137 +127,61 @@ export default [
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
     ],
     name: 'price',
     outputs: [
-      {
-        internalType: 'uint192',
-        name: 'low',
-        type: 'uint192',
-      },
-      {
-        internalType: 'uint192',
-        name: 'high',
-        type: 'uint192',
-      },
+      { internalType: 'uint192', name: 'low', type: 'uint192' },
+      { internalType: 'uint192', name: 'high', type: 'uint192' },
     ],
     stateMutability: 'view',
     type: 'function',
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
     ],
     name: 'primeBasket',
     outputs: [
-      {
-        internalType: 'contract IERC20[]',
-        name: 'erc20s',
-        type: 'address[]',
-      },
-      {
-        internalType: 'bytes32[]',
-        name: 'targetNames',
-        type: 'bytes32[]',
-      },
-      {
-        internalType: 'uint192[]',
-        name: 'targetAmts',
-        type: 'uint192[]',
-      },
+      { internalType: 'contract IERC20[]', name: 'erc20s', type: 'address[]' },
+      { internalType: 'bytes32[]', name: 'targetNames', type: 'bytes32[]' },
+      { internalType: 'uint192[]', name: 'targetAmts', type: 'uint192[]' },
     ],
     stateMutability: 'view',
     type: 'function',
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
-      {
-        internalType: 'uint256',
-        name: 'amount',
-        type: 'uint256',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
+      { internalType: 'uint256', name: 'amount', type: 'uint256' },
     ],
     name: 'redeem',
     outputs: [
-      {
-        internalType: 'address[]',
-        name: 'tokens',
-        type: 'address[]',
-      },
-      {
-        internalType: 'uint256[]',
-        name: 'withdrawals',
-        type: 'uint256[]',
-      },
-      {
-        internalType: 'uint256[]',
-        name: 'available',
-        type: 'uint256[]',
-      },
+      { internalType: 'address[]', name: 'tokens', type: 'address[]' },
+      { internalType: 'uint256[]', name: 'withdrawals', type: 'uint256[]' },
+      { internalType: 'uint256[]', name: 'available', type: 'uint256[]' },
     ],
     stateMutability: 'nonpayable',
     type: 'function',
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
-      {
-        internalType: 'uint256',
-        name: 'amount',
-        type: 'uint256',
-      },
-      {
-        internalType: 'uint48[]',
-        name: 'basketNonces',
-        type: 'uint48[]',
-      },
-      {
-        internalType: 'uint192[]',
-        name: 'portions',
-        type: 'uint192[]',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
+      { internalType: 'uint256', name: 'amount', type: 'uint256' },
+      { internalType: 'uint48[]', name: 'basketNonces', type: 'uint48[]' },
+      { internalType: 'uint192[]', name: 'portions', type: 'uint192[]' },
     ],
     name: 'redeemCustom',
     outputs: [
-      {
-        internalType: 'address[]',
-        name: 'tokens',
-        type: 'address[]',
-      },
-      {
-        internalType: 'uint256[]',
-        name: 'withdrawals',
-        type: 'uint256[]',
-      },
+      { internalType: 'address[]', name: 'tokens', type: 'address[]' },
+      { internalType: 'uint256[]', name: 'withdrawals', type: 'uint256[]' },
     ],
     stateMutability: 'nonpayable',
     type: 'function',
   },
   {
     inputs: [
-      {
-        internalType: 'contract IRToken',
-        name: 'rToken',
-        type: 'address',
-      },
+      { internalType: 'contract IRToken', name: 'rToken', type: 'address' },
     ],
     name: 'stToken',
     outputs: [

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -15,9 +15,9 @@ export const DEPLOYER_ADDRESS: AddressMap = {
 }
 
 export const FACADE_ADDRESS: AddressMap = {
-  [ChainId.Mainnet]: '0x1639fAB05649b719d4fA541322C69F6e9811923F',
-  [ChainId.Base]: '0xe1aa15DA8b993c6312BAeD91E0b470AE405F91BF',
-  [ChainId.Hardhat]: '0x1639fAB05649b719d4fA541322C69F6e9811923F',
+  [ChainId.Mainnet]: '0x2815c24F49D5c5316Ffd0952dB0EFe68b0d5F132',
+  [ChainId.Base]: '0xDf99ccA98349DeF0eaB8eC37C1a0B270de38E682',
+  [ChainId.Hardhat]: '0x2815c24F49D5c5316Ffd0952dB0EFe68b0d5F132',
 }
 
 export const FACADE_ACT_ADDRESS: AddressMap = {

--- a/src/views/staking/atoms.ts
+++ b/src/views/staking/atoms.ts
@@ -44,10 +44,10 @@ export const pendingRSRSummaryAtom = atom<{
   const currentTime = get(blockTimestampAtom)
   return get(pendingRSRAtom).reduce(
     (acc, unstake) => {
-      acc.index = unstake.index
       acc.availableAt = unstake.availableAt
 
       if (currentTime >= unstake.availableAt) {
+        acc.index = unstake.index
         acc.availableAmount += unstake.amount
         acc.availableIndex = BigInt(acc.availableAt)
       } else {

--- a/src/views/staking/components/balances/PendingBalance.tsx
+++ b/src/views/staking/components/balances/PendingBalance.tsx
@@ -34,7 +34,7 @@ const PendingBalance = () => {
       <Text variant="subtitle" mb={3}>
         <Trans>In Cooldown</Trans>
       </Text>
-      <TokenBalance symbol={'RSR'} balance={balance * rate} />
+      <TokenBalance symbol={'RSR'} balance={balance} />
       {!isLegacy && (
         <TransactionButton
           small


### PR DESCRIPTION
Queries storage slot (again) to get `draftEra`

Also, fixes reducer to only update the `index` for withdrawals if they're passed cooldown. This bug was previously making it so that cooled down stakes couldn't be withdrawn.