### PR TITLE
fix hyUSD zapping issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@popperjs/core": "^2.11.5",
         "@rainbow-me/rainbowkit": "1.3.0",
         "@react-spring/web": "^9.7.1",
-        "@reserve-protocol/token-zapper": "3.0.9",
+        "@reserve-protocol/token-zapper": "3.0.10",
         "@tanstack/react-table": "^8.10.7",
         "@uiw/react-md-editor": "^3.20.5",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -5309,9 +5309,9 @@
       }
     },
     "node_modules/@reserve-protocol/token-zapper": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@reserve-protocol/token-zapper/-/token-zapper-3.0.9.tgz",
-      "integrity": "sha512-+Dba/3n6Z7tJGD5OqKKy8FsgZZwDgzLwo65sLbKQOR4c0FVUrCRt+BcV9gNL0zzUxlhNuht1hwHSm3yA1/KznQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@reserve-protocol/token-zapper/-/token-zapper-3.0.10.tgz",
+      "integrity": "sha512-0CpSI04kaff89XO0SGy//A3I3wclLD6Fg2/+WjSTa4USraPPAx9SZg+M+m6zjMqUByYryXJToWXzz0Nv9KPLTw==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/providers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@popperjs/core": "^2.11.5",
     "@rainbow-me/rainbowkit": "1.3.0",
     "@react-spring/web": "^9.7.1",
-    "@reserve-protocol/token-zapper": "3.0.9",
+    "@reserve-protocol/token-zapper": "3.0.10",
     "@tanstack/react-table": "^8.10.7",
     "@uiw/react-md-editor": "^3.20.5",
     "@uniswap/permit2-sdk": "^1.2.0",

--- a/src/views/issuance/components/zap/state/zapper.ts
+++ b/src/views/issuance/components/zap/state/zapper.ts
@@ -47,7 +47,7 @@ export const supportsPermit2Signatures = onlyNonNullAtom((get) => {
   return false
 })
 
-let unsub = () => { }
+let unsub = () => {}
 export const zapperState = loadable(
   atom(async (get) => {
     get(chainIdAtom)
@@ -63,7 +63,7 @@ export const zapperState = loadable(
     if (provider == null) {
       return null
     }
-    provider.on('error', () => { })
+    provider.on('error', () => {})
 
     try {
       const chainIdToConfig: Record<
@@ -128,7 +128,7 @@ export const zappableTokens = atom(async (get) => {
   const commonTokens = uni.commonTokens as Record<string, Token>
   return [
     uni.nativeToken,
-    
+
     commonTokens.USDbC,
     commonTokens.USDC,
     commonTokens.USDT,


### PR DESCRIPTION
Some slippage related code in the UI broke if the zappper was unable to price a token. This was an issue as the zapper was unable to price the curve LP tokens in the hyUSD basket.

This PR contains a fix for the zapper that makes it able to price hyUSD again. It also fixes makes the fixes makes the UI not lock up if the input or output tokens can not be priced.