### PR TITLE
Fix: rtoken card alignment

### DIFF
--- a/src/views/home/components/RTokenCard.tsx
+++ b/src/views/home/components/RTokenCard.tsx
@@ -98,6 +98,7 @@ const RTokenCard = ({ token, ...props }: Props) => {
             justifyContent: ['start', 'space-between'],
             gap: 2,
             height: '100%',
+            minHeight: '284px',
           }}
         >
           <Box
@@ -233,7 +234,7 @@ const RTokenCard = ({ token, ...props }: Props) => {
               <Box
                 variant="layout.verticalAlign"
                 sx={{ flexWrap: 'wrap', gap: [2, '12px'] }}
-                mt={[0, 2]}
+                mt={[0, 1]}
               >
                 <Button
                   medium


### PR DESCRIPTION
Before:
<img width="1467" alt="image" src="https://github.com/reserve-protocol/register/assets/11811232/b9e6b6bb-f4b2-4dfb-9576-125a891cbeac">


After:
<img width="1470" alt="image" src="https://github.com/reserve-protocol/register/assets/11811232/94dcb7e3-628b-41e8-98d8-b8a694104dde">
