### PR TITLE
Fix: temporal fix for USDC+ historical price data

### DIFF
--- a/src/views/overview/components/charts/PriceChart.tsx
+++ b/src/views/overview/components/charts/PriceChart.tsx
@@ -64,7 +64,10 @@ const PriceChart = (props: BoxProps) => {
           priceUSD: string
           basketRate: string
         }) => {
-          const value = currentPrice === 'USD' ? +priceUSD : +basketRate
+          let value = currentPrice === 'USD' ? +priceUSD : +basketRate
+          // Temporal fix for USDC+ historical price data
+          value =
+            timestamp === '1703193935' && rToken?.symbol === 'USDC+' ? 1 : value
           const display =
             currentPrice === 'USD'
               ? `$${formatCurrency(+priceUSD)}`


### PR DESCRIPTION
Before:
<img width="1247" alt="Screenshot 2024-03-21 at 14 14 48" src="https://github.com/reserve-protocol/register/assets/11811232/cdbb9b95-b2ed-4f1f-886a-ae1d3cfc90db">


After:
<img width="1224" alt="Screenshot 2024-03-21 at 14 22 24" src="https://github.com/reserve-protocol/register/assets/11811232/8f779a66-64ad-43b1-80a7-ccb64dffd28b">
