### PR TITLE
chore: add earn pools

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -247,3 +247,8 @@ export const collateralDisplay: Record<string, string> = {
   wsgusdbc: 'Stargate Base USDbC',
   saethusdc: 'AAVE USDC V3',
 }
+
+export const EXTRA_UNDERLYING_TOKENS_POOLS = [
+  '0x5bfb340fa9305abb164fb0248d0d82fc3d82c3bb',
+  '0xb5e331615fdba7df49e05cdeaceb14acdd5091c3',
+]

--- a/src/views/earn/hooks/useRTokenPools.ts
+++ b/src/views/earn/hooks/useRTokenPools.ts
@@ -8,7 +8,7 @@ import useSWRImmutable from 'swr/immutable'
 import { StringMap } from 'types'
 import { EUSD_ADDRESS, RSR_ADDRESS } from 'utils/addresses'
 import { ChainId } from 'utils/chains'
-import { LP_PROJECTS, RSR } from 'utils/constants'
+import { EXTRA_UNDERLYING_TOKENS_POOLS, LP_PROJECTS, RSR } from 'utils/constants'
 
 // Only map what I care about the response...
 interface DefillamaPool {
@@ -124,7 +124,9 @@ const useRTokenPools = () => {
 
       for (const pool of data) {
         const rToken = pool.underlyingTokens?.find(
-          (token: string) => !!listedRTokens[token?.toLowerCase()]
+          (token: string) =>
+            !!listedRTokens[token?.toLowerCase()] ||
+            EXTRA_UNDERLYING_TOKENS_POOLS.includes(token?.toLowerCase())
         )
 
         if (rToken && pool.project !== 'reserve') {


### PR DESCRIPTION
Added new underlying tokens to Register to track these tokens:
Volatile AMM - hyUSD/eUSD: 0xb5E331615FdbA7DF49e05CdEACEb14Acdd5091c3
Stable AMM - eUSD/USDbC: 0x5BfB340FA9305abB164Fb0248D0D82FC3D82C3bb