### PR TITLE
Fix user facing typo in the new zap interface (ZapDetails.tsx)

### DIFF
--- a/src/views/issuance/components/zapV2/overview/ZapDetails.tsx
+++ b/src/views/issuance/components/zapV2/overview/ZapDetails.tsx
@@ -19,7 +19,7 @@ const ZapDetails = ({ hideGasCost, ...props }: Props) => {
         variant="layout.verticalAlign"
         sx={{ justifyContent: 'space-between' }}
       >
-        <Text sx={{ fontSize: 14 }}>Price Imapct</Text>
+        <Text sx={{ fontSize: 14 }}>Price Impact</Text>
         {loadingZap ? (
           <Skeleton width={36} height={10} />
         ) : (


### PR DESCRIPTION
Yes I know what you're thinking: this guy must be airdrop farming with his low hanging fixes! But no, this is a genuine user reporting a typo in the new Zap In interface on the Reserve website that was bothering me ;) 

Example:
![image](https://github.com/reserve-protocol/register/assets/61325205/1d9cfc31-12b7-443a-aca9-4d53b345472c)
