### PR TITLE
show 0% trade when lotsize is 0

### DIFF
--- a/src/views/index-dtf/auctions/components/auction-item.tsx
+++ b/src/views/index-dtf/auctions/components/auction-item.tsx
@@ -525,9 +525,12 @@ const TradePreview = ({ trade }: { trade: AssetTrade }) => {
   const expectedBasket = useAtomValue(expectedBasketAtom)?.basket
   const isCompleted = trade.state === TRADE_STATE.COMPLETED
 
+  const sellDelta = expectedBasket?.[trade.sell.address]?.delta || 0
+  const buyDelta = expectedBasket?.[trade.buy.address]?.delta || 0
+
   const delta = Math.min(
-    Math.abs(expectedBasket?.[trade.sell.address]?.delta || 0),
-    Math.abs(Math.max(expectedBasket?.[trade.buy.address]?.delta || 0, 0))
+    sellDelta > 0 ? Math.abs(sellDelta) : 0,
+    buyDelta < 0 ? Math.abs(buyDelta) : 0
   )
 
   return (
@@ -563,7 +566,8 @@ const TradePreview = ({ trade }: { trade: AssetTrade }) => {
             }
             to={
               expectedBasket?.[trade.sell.address]?.targetShares
-                ? Number(expectedBasket?.[trade.sell.address]?.currentShares) - delta
+                ? Number(expectedBasket?.[trade.sell.address]?.currentShares) -
+                  delta
                 : undefined
             }
           />
@@ -604,7 +608,8 @@ const TradePreview = ({ trade }: { trade: AssetTrade }) => {
             }
             to={
               expectedBasket?.[trade.buy.address]?.targetShares
-                ? Number(expectedBasket?.[trade.buy.address]?.currentShares) + delta
+                ? Number(expectedBasket?.[trade.buy.address]?.currentShares) +
+                  delta
                 : undefined
             }
           />


### PR DESCRIPTION
problem was that UI was showing trades as possible that were not, when a token on the sell side became in deficit relative to its ideal target or a token on the buy side became in surplus relative to the ideal target