### PR TITLE
fix(index-dtf): bps-precise fee distribution during deployment

### DIFF
--- a/docs/wiki/progress.md
+++ b/docs/wiki/progress.md
@@ -1,6 +1,6 @@
 ---
 title: Progress
-updated: 2026-07-31
+updated: 2026-08-04
 type: ledger
 ---
 
@@ -10,6 +10,7 @@ Stage ledger. One row per stage; keep entries short. Verifier = exact fresh comm
 
 | Stage | Status | Verifier | Review | Next |
 |---|---|---|---|---|
+| deploy fee distribution bps precision (shared `utils/fees` helpers) | human-review-required (base 76c047530) | gate green: typecheck + lint + 864 unit (11 new) · 72 helper · smoke 59 · new `general/deploy/index-dtf-revenue` desktop+mobile+full · propose-dtf-settings 3/3 · RED-verified: integer fee → `33 %`; float even-split → `33.33` not `33.34` | correctness+security+product+complexity: self, per-claim — bps floor never exceeds the pot, remainder still lands on the last recipient (exactly 1e18) | **Engineer review required** (on-chain fee math): BSC fee `1/3` → 33.33% everywhere (fallback too); deploy + propose share `revenuePortionFromShare`/`splitSharesEvenly` |
 | vlRSR self-appreciating vaults: drawer shares/redeem + rate line · governance card · portfolio · earn rate-corrected + APY | human-review-required (base d0427a7cf; SDK local-linked) | gate green: typecheck+lint+847 unit · 72 helper · smoke 58 · drawer spec 2/2 · live BSC visual light+dark incl. earn TVL 261.5M RSR = totalAssets | Dark + Light on both diffs; all blockers fixed; details in git | PR #1072 open on SDK 0.5.1 (published, pinned exact; direct sdk dep dropped). Companions: dtf-interface#29, reserve-api#236 (deploy w/ daos CDN purge). **Engineer review**: withdraw→redeem for ALL vaults, governance card, api token.price×rate. [plan](../plans/vlrsr-self-appreciating-vaults.md) |
 | focused-tab automatic chain switching | human-review-required (base b2fcf72c6) | lint/typecheck · unit 840 incl. 8 focus/visibility · helpers 70 · smoke 56 + 1 skipped · wiki-lint | Dark + Light: stale Index target + mutation-boundary focus recheck fixed; automatic switching preserved, background tabs passive | Engineer review wallet/chain flow; then ship |
 | vote-lock APR unified on /dtf/daos list | done (base 771c92873) | gate-equivalent green (lint/typecheck/unit, 70 helper, 56 smoke, wiki-lint) · live visual: BUILDOUT + POWER overviews and earn all 46.83% from one list request | Dark + Light, per-claim verify — adopted: list-miss/error fallback gating, plain-data return, catalog mixed-case normalization; API re-key REVERTED by Luis (sdk `getVoteLockDao` needs the DTF-address key); accepted: unlisted DTFs keep per-DTF detail cache split | pre-existing reserve-api debt flagged, not shipped: maxAge-before-await caches 500s 24h; unguarded `underlyingPrice.price` deref can 500 whole list |

--- a/e2e/TEST_MAP.md
+++ b/e2e/TEST_MAP.md
@@ -31,7 +31,7 @@ the directory).
 | Explorer | [general/explorer/render](tests/general/explorer/render.spec.ts) | transactions tab (default) render; governance tab proposals render; one chain returning malformed transactions body doesn't blank the page | none | no | filters, pagination, tokens/collaterals/revenue tabs |
 | Portfolio | [general/portfolio/state-space](tests/general/portfolio/state-space.spec.ts), [general/portfolio/partial-response](tests/general/portfolio/partial-response.spec.ts) | disconnected shows connect prompt; malformed proposal row survives, healthy row still renders | none | partial (state-space only) | connected-with-holdings render, empty-vs-past-activity-only |
 | Tokens | [general/tokens/unlisted-partial](tests/general/tokens/unlisted-partial.spec.ts) | one chain returning an rtokens-less bucket doesn't crash the table | none | no | plain listed-table render, sort |
-| Create (Index/Yield deploy) | — | — | — | — | entirely uncovered |
+| Create (Index/Yield deploy) | [general/deploy/index-dtf-revenue](tests/general/deploy/index-dtf-revenue.spec.ts) | Index deploy Fees & Distribution: fractional (1/3) platform fee shown at 0.01% precision; 0.01%-grid shares close the allocation; even distribution allocates the whole non-platform pot | none | yes (precision spec) | every other wizard step (basket, governance, roles, confirm/deploy tx) and the Yield deploy wizard uncovered |
 
 ## Index DTF (`/:chain/index-dtf/:tokenId/*`)
 
@@ -86,7 +86,9 @@ additional state coverage: [boot](tests/smoke/boot.spec.ts) (home shell),
 - Legacy v2 auctions UI and bid writes: no specs.
 - Yield DTF governance, auctions, and settings/roles: no specs at all (no
   `yield-dtf/governance|auctions|settings` dirs exist).
-- Create Index DTF / Create Yield DTF deploy wizards: no specs.
+- Create Index DTF: only the Fees & Distribution step's precision behavior is
+  covered (`general/deploy/index-dtf-revenue`); basket, governance, roles, and
+  the confirm/deploy transactions have no specs. Create Yield DTF: no specs.
 - Explorer: only 3 of the tab surfaces render-tested (transactions, governance,
   malformed-body edge); tokens/collaterals/revenue tabs, filters, and
   pagination are untested.

--- a/e2e/tests/general/deploy/index-dtf-revenue.spec.ts
+++ b/e2e/tests/general/deploy/index-dtf-revenue.spec.ts
@@ -1,0 +1,88 @@
+import {
+  encodeAbiParameters,
+  encodeFunctionData,
+  parseAbi,
+  zeroAddress,
+  type Address,
+} from 'viem'
+import { test, expect, type DtfHarness } from '../../../harness'
+
+// Index DTF deploy wizard — Fees & Distribution precision. The DAO fee registry
+// can take a fractional cut of revenue (BSC takes 1/3 → 33.33%); the wizard must
+// show and split it on the same 0.01% grid its share inputs accept, or the shares
+// can never total 100% and every recipient portion drifts.
+test.use({ wallet: false })
+
+const INDEX_DEPLOYER = '0x4D201a6e5BF975E2CEE9e5cbDfc803C0Ff122073' // mainnet — the form's default chain
+const FEE_REGISTRY = '0x1234567890123456789012345678901234567890' as Address
+const DAO_FEE_REGISTRY = '0x9980cb23' // daoFeeRegistry()
+const FEE_DETAILS_ABI = parseAbi([
+  'function getFeeDetails(address rToken) view returns (address recipient, uint256 feeNumerator, uint256 feeDenominator, uint256 feeFloor)',
+])
+
+// No folio exists yet, so the wizard reads the deployer's registry with the zero
+// address. numerator/denominator = 1/3 → 33.333…% of revenue.
+async function openFeesStep(harness: DtfHarness) {
+  harness.mock
+    .ethCall(
+      INDEX_DEPLOYER,
+      DAO_FEE_REGISTRY,
+      encodeAbiParameters([{ type: 'address' }], [FEE_REGISTRY])
+    )
+    .ethCall(
+      FEE_REGISTRY,
+      encodeFunctionData({
+        abi: FEE_DETAILS_ABI,
+        functionName: 'getFeeDetails',
+        args: [zeroAddress],
+      }),
+      encodeAbiParameters(
+        [
+          { type: 'address' },
+          { type: 'uint256' },
+          { type: 'uint256' },
+          { type: 'uint256' },
+        ],
+        [FEE_REGISTRY, 1n, 3n, 0n]
+      )
+    )
+
+  const { page } = harness
+  await page.goto('/internal/deploy')
+  await page.getByTestId('deploy-step-revenue-distribution').click()
+
+  // 1/3 of revenue on the 0.01% grid — NOT the integer-truncated 33%.
+  await expect(page.getByTestId('deploy-platform-fee')).toHaveText('33.33 %', {
+    timeout: 15_000,
+  })
+
+  return page
+}
+
+test('deploy fees: hundredths-of-a-percent shares close the allocation @smoke @mobile', async ({
+  harness,
+}) => {
+  const page = await openFeesStep(harness)
+
+  await page.getByTestId('deploy-share-deployerShare').fill('0.01')
+  await page.getByTestId('deploy-share-governanceShare').fill('66.66')
+
+  await expect(page.getByTestId('deploy-remaining-allocation')).toHaveText('0%')
+})
+
+test('deploy fees: even distribution allocates the whole non-platform pot', async ({
+  harness,
+}) => {
+  const page = await openFeesStep(harness)
+
+  await page.getByTestId('deploy-even-distribution').click()
+
+  // 66.67% over two participants — the last one absorbs the odd basis point.
+  await expect(page.getByTestId('deploy-share-deployerShare')).toHaveValue(
+    '33.33'
+  )
+  await expect(page.getByTestId('deploy-share-governanceShare')).toHaveValue(
+    '33.34'
+  )
+  await expect(page.getByTestId('deploy-remaining-allocation')).toHaveText('0%')
+})

--- a/src/hooks/use-platform-fee.ts
+++ b/src/hooks/use-platform-fee.ts
@@ -2,6 +2,7 @@ import daoFeeRegistryAbi from '@/abis/dao-fee-registry-abi'
 import dtfIndexDeployerAbi from '@/abis/dtf-index-deployer-abi'
 import { INDEX_DEPLOYER_ADDRESS } from '@/utils/addresses'
 import { FALLBACK_PLATFORM_FEES } from '@/utils/constants'
+import { platformFeePercent } from '@/utils/fees'
 import { Address, zeroAddress } from 'viem'
 import { useReadContract } from 'wagmi'
 
@@ -29,7 +30,7 @@ const usePlatformFee = (chainId: number): number => {
   if (!feeDetails) return fallback
 
   const [, feeNumerator, feeDenominator] = feeDetails
-  return Number(feeNumerator * 100n / feeDenominator)
+  return platformFeePercent(feeNumerator, feeDenominator) ?? fallback
 }
 
 export default usePlatformFee

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -291,7 +291,7 @@ export const INDEX_DTF_CHAINS = [
 export const FALLBACK_PLATFORM_FEES: Record<number, number> = {
   [ChainId.Mainnet]: 50,
   [ChainId.Base]: 50,
-  [ChainId.BSC]: 33,
+  [ChainId.BSC]: 33.33,
 }
 
 // Load environment variables.

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -44,6 +44,37 @@ export const revenuePortionFromShare = (
     : (shareBps * ONE) / TOTAL_BPS
 }
 
+// Rounding each contract portion to the 0.01% grid independently can leave the
+// displayed shares a few hundredths off the pot, which reads back as an
+// over/under-allocated form nobody edited. The largest share absorbs the drift;
+// a gap bigger than one grid step per share is real, so it is left alone.
+export const absorbShareDrift = (
+  shares: number[],
+  totalPercent: number
+): number[] => {
+  if (!shares.length || !Number.isFinite(totalPercent)) return shares
+
+  const driftBps =
+    toBps(totalPercent) - shares.reduce((sum, share) => sum + toBps(share), 0n)
+
+  const tolerance = BigInt(shares.length)
+
+  if (driftBps === 0n || driftBps > tolerance || driftBps < -tolerance)
+    return shares
+
+  const largest = shares.reduce(
+    (best, share, index) => (share > shares[best] ? index : best),
+    0
+  )
+  const correctedBps = toBps(shares[largest]) + driftBps
+
+  if (correctedBps < 0n) return shares
+
+  return shares.map((share, index) =>
+    index === largest ? Number(correctedBps) / BPS_PER_PERCENT : share
+  )
+}
+
 // Even split of a pot across participants; the last one absorbs the remainder so the shares total the pot exactly.
 export const splitSharesEvenly = (
   totalPercent: number,

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -5,3 +5,59 @@ export const isDisplayablePlatformFee = (platformFee: number): boolean =>
 // Converts a contract percentage (share of NON-platform revenue) to share of total; guard with isDisplayablePlatformFee first.
 export const getFeePercentAdjust = (platformFee: number): number =>
   100 / (100 - platformFee)
+
+// Revenue shares are entered at 0.01% precision, so every fee percentage lives on
+// the same basis-point grid — otherwise the shares can never total 100%.
+const BPS_PER_PERCENT = 100
+const TOTAL_BPS = 100n * BigInt(BPS_PER_PERCENT)
+const ONE = 10n ** 18n
+
+const toBps = (percent: number): bigint =>
+  BigInt(Math.round(percent * BPS_PER_PERCENT))
+
+export const quantizeFeePercent = (percent: number): number =>
+  Number.isFinite(percent) ? Number(toBps(percent)) / BPS_PER_PERCENT : percent
+
+// Platform fee percentage from the DAO fee registry's fraction; undefined when unreadable.
+export const platformFeePercent = (
+  numerator: bigint,
+  denominator: bigint
+): number | undefined =>
+  denominator === 0n
+    ? undefined
+    : quantizeFeePercent(
+        Number((numerator * 10n ** 9n) / denominator) / 10 ** 7
+      )
+
+// Share of TOTAL revenue → the contract's portion of the NON-platform pot, in 18 decimals.
+export const revenuePortionFromShare = (
+  sharePercent: number,
+  platformFee: number
+): bigint => {
+  if (!Number.isFinite(sharePercent) || !Number.isFinite(platformFee)) return 0n
+
+  const shareBps = toBps(sharePercent)
+  const nonPlatformBps = TOTAL_BPS - toBps(platformFee)
+
+  return nonPlatformBps > 0n
+    ? (shareBps * ONE) / nonPlatformBps
+    : (shareBps * ONE) / TOTAL_BPS
+}
+
+// Even split of a pot across participants; the last one absorbs the remainder so the shares total the pot exactly.
+export const splitSharesEvenly = (
+  totalPercent: number,
+  participants: number
+): number[] => {
+  if (participants <= 0) return []
+
+  const totalBps = toBps(totalPercent)
+  const baseBps = totalBps / BigInt(participants)
+  const lastBps = totalBps - baseBps * BigInt(participants - 1)
+
+  return Array.from(
+    { length: participants },
+    (_, index) =>
+      Number(index === participants - 1 ? lastBps : baseBps) / BPS_PER_PERCENT
+  )
+}

--- a/src/utils/tests/fees.test.ts
+++ b/src/utils/tests/fees.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { parseEther } from 'viem'
 import {
+  absorbShareDrift,
   getFeePercentAdjust,
   isDisplayablePlatformFee,
   platformFeePercent,
@@ -94,6 +95,26 @@ describe('revenuePortionFromShare', () => {
 
   it('falls back to the share of total when the pot is empty', () => {
     expect(revenuePortionFromShare(50, 100)).toBe(parseEther('0.5'))
+  })
+})
+
+describe('absorbShareDrift', () => {
+  it('puts a hundredth of drift on the largest share', () => {
+    expect(absorbShareDrift([56.72, 4.98, 4.98], 66.67)).toEqual([
+      56.71, 4.98, 4.98,
+    ])
+    expect(absorbShareDrift([56.7, 4.98, 4.98], 66.67)).toEqual([
+      56.71, 4.98, 4.98,
+    ])
+  })
+
+  it('leaves shares that already total the pot untouched', () => {
+    expect(absorbShareDrift([33.33, 33.34], 66.67)).toEqual([33.33, 33.34])
+  })
+
+  it('leaves a real mismatch alone', () => {
+    expect(absorbShareDrift([50, 10], 66.67)).toEqual([50, 10])
+    expect(absorbShareDrift([], 66.67)).toEqual([])
   })
 })
 

--- a/src/utils/tests/fees.test.ts
+++ b/src/utils/tests/fees.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { getFeePercentAdjust, isDisplayablePlatformFee } from '../fees'
+import { parseEther } from 'viem'
+import {
+  getFeePercentAdjust,
+  isDisplayablePlatformFee,
+  platformFeePercent,
+  quantizeFeePercent,
+  revenuePortionFromShare,
+  splitSharesEvenly,
+} from '../fees'
 
 describe('isDisplayablePlatformFee', () => {
   it('accepts a finite fee in [0, 100)', () => {
@@ -32,5 +40,74 @@ describe('getFeePercentAdjust', () => {
     // platformFee 50 → 100/50 = 2 → a contract 80% displays as 40%
     expect(getFeePercentAdjust(50)).toBe(2)
     expect(getFeePercentAdjust(20)).toBe(100 / 80)
+  })
+})
+
+describe('platformFeePercent', () => {
+  it('keeps basis-point precision for a fractional registry fee', () => {
+    // BSC DAO fee registry: numerator/denominator = 1/3 → 33.333…% of revenue.
+    // Integer rounding reported it as 33%, which shifted every recipient share.
+    expect(platformFeePercent(333333333333333333n, 10n ** 18n)).toBe(33.33)
+  })
+
+  it('reads an exact fee unchanged', () => {
+    expect(platformFeePercent(5n * 10n ** 17n, 10n ** 18n)).toBe(50)
+    expect(platformFeePercent(0n, 10n ** 18n)).toBe(0)
+  })
+
+  it('is undefined for a zero denominator (unreadable registry)', () => {
+    expect(platformFeePercent(1n, 0n)).toBeUndefined()
+  })
+})
+
+describe('quantizeFeePercent', () => {
+  it('snaps to the 0.01% grid the share inputs accept', () => {
+    expect(quantizeFeePercent(33.333333333333336)).toBe(33.33)
+    expect(quantizeFeePercent(50)).toBe(50)
+  })
+
+  it('passes through a non-finite value untouched', () => {
+    expect(quantizeFeePercent(NaN)).toBeNaN()
+  })
+})
+
+describe('revenuePortionFromShare', () => {
+  it('gives the whole non-platform pot to a share equal to it', () => {
+    expect(revenuePortionFromShare(66.67, 33.33)).toBe(parseEther('1'))
+    expect(revenuePortionFromShare(50, 50)).toBe(parseEther('1'))
+  })
+
+  it('never exceeds the pot for a fractional platform fee', () => {
+    // parseEther on the float quotient overflowed 1e18 here (66.67/66.6667).
+    expect(revenuePortionFromShare(66.67, 33.33)).toBeLessThanOrEqual(
+      parseEther('1')
+    )
+    expect(revenuePortionFromShare(33.34, 33.33)).toBeLessThanOrEqual(
+      parseEther('1')
+    )
+  })
+
+  it('scales a partial share by the non-platform pot', () => {
+    expect(revenuePortionFromShare(25, 50)).toBe(parseEther('0.5'))
+    expect(revenuePortionFromShare(60, 0)).toBe(parseEther('0.6'))
+  })
+
+  it('falls back to the share of total when the pot is empty', () => {
+    expect(revenuePortionFromShare(50, 100)).toBe(parseEther('0.5'))
+  })
+})
+
+describe('splitSharesEvenly', () => {
+  it('totals the pot exactly when it does not divide evenly', () => {
+    expect(splitSharesEvenly(66.67, 2)).toEqual([33.33, 33.34])
+    expect(splitSharesEvenly(66.67, 3)).toEqual([22.22, 22.22, 22.23])
+  })
+
+  it('splits an even pot into equal shares', () => {
+    expect(splitSharesEvenly(50, 2)).toEqual([25, 25])
+  })
+
+  it('returns nothing without participants', () => {
+    expect(splitSharesEvenly(50, 0)).toEqual([])
   })
 })

--- a/src/views/index-dtf/deploy/components/basic-input.tsx
+++ b/src/views/index-dtf/deploy/components/basic-input.tsx
@@ -20,7 +20,8 @@ export type BasicInputProps = {
   highlightLabel?: boolean
   decimalPlaces?: number
   autoFocus?: boolean
-  inputProps?: React.ComponentProps<typeof Input>,
+  testId?: string
+  inputProps?: React.ComponentProps<typeof Input>
 }
 
 const BasicInput = ({
@@ -34,6 +35,7 @@ const BasicInput = ({
   highlightLabel = false,
   autoFocus = false,
   decimalPlaces,
+  testId,
   inputProps,
   ...props
 }: React.HTMLAttributes<HTMLDivElement> & BasicInputProps) => {
@@ -78,6 +80,7 @@ const BasicInput = ({
                   }
                 }}
                 type={type}
+                data-testid={testId}
                 placeholder={placeholder}
                 startAdornment={
                   labelPosition === 'start' ? adornment : undefined

--- a/src/views/index-dtf/deploy/components/deploy-accordion.tsx
+++ b/src/views/index-dtf/deploy/components/deploy-accordion.tsx
@@ -131,6 +131,7 @@ const DeployAccordionTrigger = ({
 
   return (
     <AccordionTrigger
+      data-testid={`deploy-step-${id}`}
       withChevron={false}
       className={cn(
         'flex items-center justify-between w-full p-6',
@@ -238,27 +239,29 @@ const DeployAccordion = () => {
         }
       }}
     >
-      {DEPLOY_STEPS.filter((step) => !readonlySteps.has(step.id)).map(({ id, icon, title, titleSecondary, content }) => (
-        <AccordionItem
-          key={id}
-          value={id}
-          id={`deploy-section-${id}`}
-          className="[&:not(:last-child)]:border-b-4 [&:not(:first-child)]:border-t border-secondary rounded-[1.25rem] bg-card"
-        >
-          <DeployAccordionTrigger
-            id={id}
-            icon={icon}
-            title={title}
-            validated={validatedSections[id]}
-          />
-          <AccordionContent className="flex flex-col animate-fade-in">
-            <div className="text-2xl font-bold text-primary ml-6 mb-2">
-              {t(titleSecondary)}
-            </div>
-            {content}
-          </AccordionContent>
-        </AccordionItem>
-      ))}
+      {DEPLOY_STEPS.filter((step) => !readonlySteps.has(step.id)).map(
+        ({ id, icon, title, titleSecondary, content }) => (
+          <AccordionItem
+            key={id}
+            value={id}
+            id={`deploy-section-${id}`}
+            className="[&:not(:last-child)]:border-b-4 [&:not(:first-child)]:border-t border-secondary rounded-[1.25rem] bg-card"
+          >
+            <DeployAccordionTrigger
+              id={id}
+              icon={icon}
+              title={title}
+              validated={validatedSections[id]}
+            />
+            <AccordionContent className="flex flex-col animate-fade-in">
+              <div className="text-2xl font-bold text-primary ml-6 mb-2">
+                {t(titleSecondary)}
+              </div>
+              {content}
+            </AccordionContent>
+          </AccordionItem>
+        )
+      )}
     </Accordion>
   )
 }

--- a/src/views/index-dtf/deploy/permissionless-defaults.ts
+++ b/src/views/index-dtf/deploy/permissionless-defaults.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@/utils/chains'
+import { quantizeFeePercent } from '@/utils/fees'
 import { Address, zeroAddress } from 'viem'
 import { DeployInputs, DeployStepId } from './form-fields'
 
@@ -59,7 +60,7 @@ export const getPermissionlessDefaults = (
     // Fees
     folioFee: 0.15,
     mintFee: 0.15,
-    governanceShare: 100 - platformFee,
+    governanceShare: quantizeFeePercent(100 - platformFee),
     deployerShare: 0,
     fixedPlatformFee: platformFee,
     additionalRevenueRecipients: [],

--- a/src/views/index-dtf/deploy/steps/revenue/revenue-distribution-settings.tsx
+++ b/src/views/index-dtf/deploy/steps/revenue/revenue-distribution-settings.tsx
@@ -143,6 +143,12 @@ const EvenDistributionButton = () => {
           })
         )
       )
+
+      // The recipient inputs register per index, and a write to the array alone
+      // leaves them showing their old share.
+      additionalShares.forEach((share, index) =>
+        setValue(`additionalRevenueRecipients[${index}].share`, share)
+      )
     }
   }, [getValues, setValue, selectedGovOption])
 

--- a/src/views/index-dtf/deploy/steps/revenue/revenue-distribution-settings.tsx
+++ b/src/views/index-dtf/deploy/steps/revenue/revenue-distribution-settings.tsx
@@ -3,13 +3,10 @@ import { msg } from '@lingui/core/macro'
 import { Trans, useLingui } from '@lingui/react/macro'
 import type { MessageDescriptor } from '@lingui/core'
 import { useAtomValue } from 'jotai'
-import {
-  Landmark,
-  LandPlot,
-  TrainTrack,
-} from 'lucide-react'
+import { Landmark, LandPlot, TrainTrack } from 'lucide-react'
 import { ReactNode, useCallback, useEffect } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
+import { splitSharesEvenly } from '@/utils/fees'
 import { selectedGovernanceOptionAtom } from '../../atoms'
 import BasicInput from '../../components/basic-input'
 import { Decimal } from '../../utils/decimals'
@@ -96,7 +93,10 @@ const RemainingAllocation = () => {
       <span className="text-muted-foreground">
         <Trans>Remaining allocation:</Trans>
       </span>{' '}
-      <span className={isNegative ? 'text-red-500' : ''}>
+      <span
+        data-testid="deploy-remaining-allocation"
+        className={isNegative ? 'text-red-500' : ''}
+      >
         {isNegative ? `-${displayValue}` : displayValue}%
       </span>
     </div>
@@ -120,25 +120,26 @@ const EvenDistributionButton = () => {
     ].filter(Boolean).length
 
     const remainingPercentage = new Decimal(100).minus(platformFee)
-    const baseShare =
-      Math.floor((remainingPercentage.value / participantsCount) * 100) / 100
-    const totalPercentage = baseShare * (participantsCount - 1)
-    const lastShare = +(remainingPercentage.value - totalPercentage).toFixed(2)
+    const shares = splitSharesEvenly(
+      remainingPercentage.value,
+      participantsCount
+    )
 
-    setValue('deployerShare', baseShare)
+    setValue('deployerShare', shares[0])
 
     if (isGovSharePresent) {
-      setValue('governanceShare', baseShare)
+      setValue('governanceShare', shares[1])
     }
 
     if (isAdditionalRecipientsPresent) {
+      const additionalShares = shares.slice(isGovSharePresent ? 2 : 1)
+
       setValue(
         'additionalRevenueRecipients',
         additionalRecipients.map(
           (recipient: { address: string; share: number }, index: number) => ({
             ...recipient,
-            share:
-              index === additionalRecipients.length - 1 ? lastShare : baseShare,
+            share: additionalShares[index],
           })
         )
       )
@@ -148,6 +149,7 @@ const EvenDistributionButton = () => {
   return (
     <Button
       variant="accent"
+      data-testid="deploy-even-distribution"
       className="flex gap-2 text-base pl-3 pr-4 rounded-xl text-nowrap w-48 py-7 -mr-2 bg-muted/80"
       onClick={onEvenDistribution}
     >
@@ -198,13 +200,17 @@ const RevenueDistributionSettings = () => {
               </div>
             </div>
             {disabled ? (
-              <div className="flex justify-end items-center gap-1 font-semibold px-[18px] border-lg bg-muted-foreground/5 rounded-lg w-19 h-10 flex-nowrap">
+              <div
+                data-testid="deploy-platform-fee"
+                className="flex justify-end items-center gap-1 font-semibold px-[18px] border-lg bg-muted-foreground/5 rounded-lg w-19 h-10 flex-nowrap"
+              >
                 {currentPlatformFee} %
               </div>
             ) : (
               <BasicInput
                 className="max-w-32"
                 fieldName={field}
+                testId={`deploy-share-${field}`}
                 label="%"
                 placeholder="0"
                 defaultValue={0}

--- a/src/views/index-dtf/deploy/tests/permissionless-defaults.test.ts
+++ b/src/views/index-dtf/deploy/tests/permissionless-defaults.test.ts
@@ -40,6 +40,18 @@ describe('getPermissionlessDefaults', () => {
     expect(total).toBe(100)
   })
 
+  it('revenue shares sum to 100% with a fractional platform fee', () => {
+    // BSC DAO fee registry takes 1/3 of revenue → 33.33% on the 0.01% grid
+    const defaults = getPermissionlessDefaults(56, 33.33)
+
+    expect(defaults.governanceShare).toBe(66.67)
+    expect(
+      defaults.governanceShare +
+        defaults.deployerShare +
+        defaults.fixedPlatformFee
+    ).toBe(100)
+  })
+
   it('deployer share is always 0', () => {
     expect(getPermissionlessDefaults(1, 50).deployerShare).toBe(0)
     expect(getPermissionlessDefaults(8453, 50).deployerShare).toBe(0)

--- a/src/views/index-dtf/deploy/utils/index.ts
+++ b/src/views/index-dtf/deploy/utils/index.ts
@@ -6,6 +6,7 @@ import { Address, erc20Abi, isAddress, parseEther } from 'viem'
 import { readContract } from 'wagmi/actions'
 import { FeeRecipient } from '../steps/confirm-deploy/manual/components/confirm-manual-deploy-button'
 import { AvailableChain } from '@/utils/chains'
+import { revenuePortionFromShare } from '@/utils/fees'
 
 export const isERC20 = async (address: Address, chainId: number) => {
   try {
@@ -77,36 +78,25 @@ export const isNotStRSR = async (address: Address, chainId: number) => {
   return !Boolean(await getStRSR(address, chainId))
 }
 
-const calculateShare = (sharePercentage: number, denominator: number) => {
-  const share = sharePercentage / 100
-
-  if (denominator > 0) {
-    const shareNumerator = share / denominator
-    return parseEther(shareNumerator.toString())
-  }
-
-  return parseEther(share.toString())
-}
-
 export const calculateRevenueDistribution = (
   formData: DeployInputs,
   wallet: Address,
   stToken?: Address
 ) => {
-  const totalSharesDenominator = (100 - formData.fixedPlatformFee) / 100
+  const platformFee = formData.fixedPlatformFee
 
   let revenueDistribution: FeeRecipient[] = (
     formData.additionalRevenueRecipients || []
   ).map((recipient) => ({
     recipient: recipient.address,
-    portion: calculateShare(recipient.share, totalSharesDenominator),
+    portion: revenuePortionFromShare(recipient.share, platformFee),
   }))
 
   // Add deployer share if not the last one
   if (formData.deployerShare > 0) {
     revenueDistribution.push({
       recipient: wallet,
-      portion: calculateShare(formData.deployerShare, totalSharesDenominator),
+      portion: revenuePortionFromShare(formData.deployerShare, platformFee),
     })
   }
 
@@ -114,7 +104,7 @@ export const calculateRevenueDistribution = (
   if (formData.governanceShare > 0 && stToken) {
     revenueDistribution.push({
       recipient: stToken,
-      portion: calculateShare(formData.governanceShare, totalSharesDenominator),
+      portion: revenuePortionFromShare(formData.governanceShare, platformFee),
     })
   }
 

--- a/src/views/index-dtf/deploy/utils/tests/revenue-distribution.test.ts
+++ b/src/views/index-dtf/deploy/utils/tests/revenue-distribution.test.ts
@@ -173,6 +173,59 @@ describe('calculateRevenueDistribution', () => {
     expect(totalPortion).toBe(parseEther('1'))
   })
 
+  it('gives the whole pot to a single share matching a fractional platform fee', () => {
+    // BSC platform fee is 33.33% (1/3 of revenue) — a 66.67% governance share IS
+    // the entire non-platform pot, so the portion must be exactly 1e18, never above.
+    const data = {
+      ...baseFormData,
+      governanceShare: 66.67,
+      deployerShare: 0,
+      fixedPlatformFee: 33.33,
+    } as DeployInputs
+
+    const result = calculateRevenueDistribution(data, WALLET, ST_TOKEN)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].portion).toBe(parseEther('1'))
+  })
+
+  it('keeps hundredths-of-a-percent shares distinct under a fractional platform fee', () => {
+    const data = {
+      ...baseFormData,
+      governanceShare: 33.34,
+      deployerShare: 33.33,
+      fixedPlatformFee: 33.33,
+    } as DeployInputs
+
+    const result = calculateRevenueDistribution(data, WALLET, ST_TOKEN)
+
+    const deployer = result.find((r) => r.recipient === WALLET)!
+    const governance = result.find((r) => r.recipient === ST_TOKEN)!
+
+    // 33.33/66.67 and 33.34/66.67 of the pot — a 0.01% edit must move the portion
+    expect(deployer.portion).toBe((3333n * parseEther('1')) / 6667n)
+    expect(governance.portion).toBe(parseEther('1') - deployer.portion)
+    expect(deployer.portion + governance.portion).toBe(parseEther('1'))
+  })
+
+  it('totals exactly 1 ether across many decimal shares', () => {
+    const data = {
+      ...baseFormData,
+      governanceShare: 20.01,
+      deployerShare: 13.33,
+      fixedPlatformFee: 33.33,
+      additionalRevenueRecipients: [
+        { address: RECIPIENT_1, share: 16.66 },
+        { address: RECIPIENT_2, share: 16.67 },
+      ],
+    } as DeployInputs
+
+    const result = calculateRevenueDistribution(data, WALLET, ST_TOKEN)
+
+    expect(result).toHaveLength(4)
+    expect(result.reduce((sum, r) => sum + r.portion, 0n)).toBe(parseEther('1'))
+  })
+
   it('applies denominator based on platform fee', () => {
     // platformFee = 50 → denominator = (100-50)/100 = 0.5
     // governanceShare = 50 → share = 50/100 = 0.5 → portion = 0.5/0.5 = 1.0

--- a/src/views/index-dtf/governance/CLAUDE.md
+++ b/src/views/index-dtf/governance/CLAUDE.md
@@ -106,6 +106,12 @@ mapper dereferences — serve proposals ONLY through it or the list breaks).
   `balanceOf`; specs asserting a real rate override per-address (see
   `flows/vote-lock-drawer.spec.ts`). The unlock tx is `redeem(shares)` for ALL
   vaults — assert decoded share args, not asset amounts.
+- Revenue-share math is shared with the deploy wizard: percentages of TOTAL
+  revenue become contract portions of the NON-platform pot through
+  `revenuePortionFromShare` (`src/utils/fees.ts`), on a 0.01% basis-point grid —
+  the DAO fee registry can hold a fractional fee (BSC = 1/3 → 33.33%), so float
+  division or an integer fee makes the shares unable to total 100%. Even-split
+  buttons use `splitSharesEvenly`. Don't reintroduce local float math here.
 - ERC-6372 `clock()` is mocked (timestamp mode); governor deadline math
   breaks silently if a new read bypasses the frozen clock.
 - Threshold change-detection MUST go through the shared

--- a/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/atoms.ts
+++ b/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/atoms.ts
@@ -15,6 +15,7 @@ import {
 import { Token } from '@/types'
 import { BIGINT_MAX } from '@/utils/constants'
 import {
+  absorbShareDrift,
   getFeePercentAdjust,
   isDisplayablePlatformFee,
   revenuePortionFromShare,
@@ -946,9 +947,24 @@ export const feeRecipientsAtom = atom((get) => {
     }
   }
 
+  // Per-recipient rounding can leave the shares a hundredth off the pot, which
+  // would render an untouched form as over/under-allocated.
+  const [correctedDeployer, correctedGovernance, ...correctedExternal] =
+    absorbShareDrift(
+      [
+        deployerShare,
+        governanceShare,
+        ...externalRecipients.map((r) => r.share),
+      ],
+      100 - platformFee
+    )
+
   return {
-    deployerShare,
-    governanceShare,
-    externalRecipients,
+    deployerShare: correctedDeployer,
+    governanceShare: correctedGovernance,
+    externalRecipients: externalRecipients.map((recipient, index) => ({
+      ...recipient,
+      share: correctedExternal[index],
+    })),
   }
 })

--- a/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/atoms.ts
+++ b/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/atoms.ts
@@ -14,7 +14,11 @@ import {
 } from '@/state/dtf/atoms'
 import { Token } from '@/types'
 import { BIGINT_MAX } from '@/utils/constants'
-import { getFeePercentAdjust, isDisplayablePlatformFee } from '@/utils/fees'
+import {
+  getFeePercentAdjust,
+  isDisplayablePlatformFee,
+  revenuePortionFromShare,
+} from '@/utils/fees'
 import type { MessageDescriptor } from '@lingui/core'
 import { msg } from '@lingui/core/macro'
 import { atom } from 'jotai'
@@ -569,16 +573,10 @@ export const dtfSettingsProposalDataAtom = atom<ProposalData | undefined>(
       const platformFee = get(indexDTFFeeAtom)
       if (!isLoaded(platformFee)) return undefined
 
-      // Convert from actual percentage (including platform fee) to contract percentage (excluding platform fee)
-      // User input: actual % of total revenue -> Contract needs: % of non-platform portion
-      // Example BSC: User inputs 67% -> Contract needs 100% (67% is 100% of the 67% non-platform portion)
-      const calculateShare = (sharePercentage: number) => {
-        // Convert actual percentage to fraction of non-platform portion
-        const actualFraction = sharePercentage / 100
-        const nonPlatformFraction = (100 - platformFee) / 100
-        const contractFraction = actualFraction / nonPlatformFraction
-        return parseEther(contractFraction.toString())
-      }
+      // Shares are entered as % of total revenue; the contract wants % of the
+      // non-platform portion (BSC: 66.67% of revenue IS the whole pot → 100%).
+      const calculateShare = (sharePercentage: number) =>
+        revenuePortionFromShare(sharePercentage, platformFee)
 
       // Get current values
       const governanceShare =

--- a/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/components/sections/propose-revenue-distribution.tsx
+++ b/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/components/sections/propose-revenue-distribution.tsx
@@ -213,6 +213,12 @@ const EvenDistributionButton = () => {
           })
         )
       )
+
+      // The recipient inputs register per index, and a write to the array alone
+      // leaves them showing their old share.
+      additionalShares.forEach((share, index) =>
+        setValue(`additionalRevenueRecipients[${index}].share`, share)
+      )
     }
   }, [getValues, setValue])
 

--- a/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/components/sections/propose-revenue-distribution.tsx
+++ b/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/components/sections/propose-revenue-distribution.tsx
@@ -7,6 +7,7 @@ import { ReactNode, useCallback } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { Address } from 'viem'
 import { cn } from '@/lib/utils'
+import { splitSharesEvenly } from '@/utils/fees'
 
 type Recipient = {
   address: Address
@@ -192,22 +193,23 @@ const EvenDistributionButton = () => {
     ].filter(Boolean).length
 
     const remainingPercentage = new Decimal(100).minus(fixedPlatformFee)
-    const baseShare =
-      Math.floor((remainingPercentage.value / participantsCount) * 100) / 100
-    const totalPercentage = baseShare * (participantsCount - 1)
-    const lastShare = +(remainingPercentage.value - totalPercentage).toFixed(2)
+    const shares = splitSharesEvenly(
+      remainingPercentage.value,
+      participantsCount
+    )
 
-    setValue('deployerShare', baseShare)
-    setValue('governanceShare', baseShare)
+    setValue('deployerShare', shares[0])
+    setValue('governanceShare', shares[1])
 
     if (isAdditionalRecipientsPresent) {
+      const additionalShares = shares.slice(2)
+
       setValue(
         'additionalRevenueRecipients',
         additionalRecipients.map(
           (recipient: { address: string; share: number }, index: number) => ({
             ...recipient,
-            share:
-              index === additionalRecipients.length - 1 ? lastShare : baseShare,
+            share: additionalShares[index],
           })
         )
       )

--- a/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/tests/fee-recipients-atom.test.ts
+++ b/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/tests/fee-recipients-atom.test.ts
@@ -1,14 +1,16 @@
 import { createStore } from 'jotai'
 import { describe, expect, it } from 'vitest'
+import { parseEther } from 'viem'
 import { indexDTFAtom, indexDTFFeeAtom } from '@/state/dtf/atoms'
+import { revenuePortionFromShare } from '@/utils/fees'
 import { feeRecipientsAtom } from '../atoms'
 
-const makeStore = (platformFee: number) => {
+const makeStore = (platformFee: number, percentage = '80') => {
   const store = createStore()
   store.set(indexDTFAtom, {
     deployer: '0x1111111111111111111111111111111111111111',
     feeRecipients: [
-      { address: '0x2222222222222222222222222222222222222222', percentage: '80' },
+      { address: '0x2222222222222222222222222222222222222222', percentage },
     ],
     stToken: { id: '0x2222222222222222222222222222222222222222' },
   } as any)
@@ -21,6 +23,17 @@ describe('feeRecipientsAtom platform-fee guard', () => {
     const result = makeStore(50).get(feeRecipientsAtom)
     // platformFee 50 → adjust 2 → 80% governance displays as 40%
     expect(result?.governanceShare).toBe(40)
+  })
+
+  it('round-trips a whole-pot share under a fractional platform fee', () => {
+    // BSC takes 1/3 of revenue: a contract 100% recipient owns 66.67% of total,
+    // and that share must encode back to the whole pot (1e18), never above it.
+    const result = makeStore(33.33, '100').get(feeRecipientsAtom)
+
+    expect(result?.governanceShare).toBe(66.67)
+    expect(revenuePortionFromShare(result!.governanceShare, 33.33)).toBe(
+      parseEther('1')
+    )
   })
 
   it('returns undefined (indeterminate) at platformFee=100 — no fabricated split', () => {

--- a/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/tests/fee-recipients-atom.test.ts
+++ b/src/views/index-dtf/governance/views/propose/views/propose-dtf-settings/tests/fee-recipients-atom.test.ts
@@ -5,18 +5,23 @@ import { indexDTFAtom, indexDTFFeeAtom } from '@/state/dtf/atoms'
 import { revenuePortionFromShare } from '@/utils/fees'
 import { feeRecipientsAtom } from '../atoms'
 
-const makeStore = (platformFee: number, percentage = '80') => {
+type Recipient = { address: string; percentage: string }
+
+const makeStoreWith = (platformFee: number, feeRecipients: Recipient[]) => {
   const store = createStore()
   store.set(indexDTFAtom, {
     deployer: '0x1111111111111111111111111111111111111111',
-    feeRecipients: [
-      { address: '0x2222222222222222222222222222222222222222', percentage },
-    ],
+    feeRecipients,
     stToken: { id: '0x2222222222222222222222222222222222222222' },
   } as any)
   store.set(indexDTFFeeAtom, platformFee)
   return store
 }
+
+const makeStore = (platformFee: number, percentage = '80') =>
+  makeStoreWith(platformFee, [
+    { address: '0x2222222222222222222222222222222222222222', percentage },
+  ])
 
 describe('feeRecipientsAtom platform-fee guard', () => {
   it('returns a split for a displayable fee', () => {
@@ -34,6 +39,32 @@ describe('feeRecipientsAtom platform-fee guard', () => {
     expect(revenuePortionFromShare(result!.governanceShare, 33.33)).toBe(
       parseEther('1')
     )
+  })
+
+  it('shows shares that total the pot when per-recipient rounding drifts', () => {
+    // 80/10/10 of the pot each round up: the naive read-back totals 66.68% of
+    // revenue, rendering an untouched form as over-allocated.
+    const result = makeStoreWith(33.33, [
+      {
+        address: '0x2222222222222222222222222222222222222222',
+        percentage: '80',
+      },
+      {
+        address: '0x3333333333333333333333333333333333333333',
+        percentage: '10',
+      },
+      {
+        address: '0x4444444444444444444444444444444444444444',
+        percentage: '10',
+      },
+    ]).get(feeRecipientsAtom)
+
+    const total =
+      result!.deployerShare +
+      result!.governanceShare +
+      result!.externalRecipients.reduce((sum, r) => sum + r.share, 0)
+
+    expect(+total.toFixed(2)).toBe(66.67)
   })
 
   it('returns undefined (indeterminate) at platformFee=100 — no fabricated split', () => {

--- a/src/views/index-dtf/index-dtf-container.tsx
+++ b/src/views/index-dtf/index-dtf-container.tsx
@@ -24,6 +24,7 @@ import { isInactiveDTF } from '@/hooks/use-dtf-status'
 import { isAddress } from '@/utils'
 import { AvailableChain } from '@/utils/chains'
 import { NETWORKS, RESERVE_API, ROUTES, ZAPPER_API } from '@/utils/constants'
+import { quantizeFeePercent } from '@/utils/fees'
 import {
   IndexDtfProvider,
   type Amount,
@@ -169,7 +170,7 @@ const IndexDtfUpdaters = () => {
 
   useEffect(() => {
     if (fee) {
-      setFee(fee.percent)
+      setFee(quantizeFeePercent(fee.percent))
     } else if (feeUnavailable) {
       setFee('unavailable')
     }


### PR DESCRIPTION
## Summary

Deployment's Fees & Distribution table couldn't express precise shares, while governance proposals could. Two separate causes:

1. The platform fee was read with integer division, so BSC's registry fee (`333333333333333333 / 1e18` = 1/3) displayed and was used as **33%** — with 33% reserved, the remaining shares could never total 100%:

```diff
-return Number((feeNumerator * 100n) / feeDenominator)   // 33
+return platformFeePercent(feeNumerator, feeDenominator) ?? fallback   // 33.33
```

2. Deploy normalized shares into contract portions in floating point (`parseEther(float.toString())`), and its "Even distribution" floored to a base share and left the pot short.

Deploy and `propose-dtf-settings` now share bps-grid helpers in `src/utils/fees.ts` — every fee percentage lives on the same 0.01% grid the inputs accept, and the share→portion conversion is bigint-only:

```ts
// share of TOTAL revenue -> contract portion of the NON-platform pot, 18 decimals
revenuePortionFromShare(share, platformFee) =
  (bps(share) * 1e18) / (10_000n - bps(platformFee))

splitSharesEvenly(pot, n)   // last participant absorbs the remainder
```

So on BSC a 66.67% governance share is now exactly `1e18` (the whole pot) instead of drifting, and a 0.01% edit actually moves the encoded portion. Callers changed: `usePlatformFee`, `calculateRevenueDistribution`, `dtfSettingsProposalDataAtom.calculateShare`, both Even-distribution buttons, `getPermissionlessDefaults`, and the SDK fee written into `indexDTFFeeAtom`. Calldata shape, recipient sorting, the last-recipient correction to exactly `1e18`, and governance's `tokenJar` routing are unchanged. The BSC fallback constant moves `33 → 33.33` to match the registry when it can't be read.

**Engineer review requested** on the fee math itself: the 1/3 → 33.33% quantization policy (round to the grid the inputs accept), and that both deploy and propose now go through the same helper.

## Testing

- 11 new unit tests: `utils/tests/fees.test.ts`, deploy `revenue-distribution.test.ts` (fractional fee gives the whole pot; hundredths stay distinct; 4 decimal shares total exactly `1e18`), governance `fee-recipients-atom.test.ts` round-trip, permissionless defaults.
- New e2e `e2e/tests/general/deploy/index-dtf-revenue.spec.ts` (strict mocks, desktop + mobile): a 1/3 registry fee renders `33.33 %`, 0.01%-grid shares close the allocation, even distribution allocates the whole pot.
- RED-verified: restoring the integer fee read renders `33 %`; restoring the float even-split gives `33.33` where `33.34` is required.
- Green: `pnpm typecheck`, `pnpm lint`, `pnpm test:run` (864), e2e helper units (72), `pnpm e2e:smoke` (59), `governance-propose-dtf-settings` 3/3, `wiki-lint`.


Link to Devin session: https://app.devin.ai/sessions/96884b34a06547fd834c57cdf9a88933
Requested by: @lcamargof

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform-fee precision, including accurate 33.33% fee display and 66.67% governance shares.
  * Ensured revenue allocations total exactly 100%, including odd basis-point remainders.
  * Improved fractional fee handling across deployment and governance proposal flows.

* **Tests**
  * Added coverage for fee precision, revenue distribution, mobile behavior, and deployment wizard allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->