### PR TITLE
test(e2e): opt-in live Reserve/zapper API validation mode (zrs1)

### DIFF
--- a/docs/wiki/domains/e2e.md
+++ b/docs/wiki/domains/e2e.md
@@ -55,6 +55,49 @@ lifecycle depth, and gaps live in `e2e/TEST_MAP.md`. `e2e/CLAUDE.md`
   a foreign server can't bypass the pinned env (`VITE_E2E` keeps production
   form validation ON, so zod bounds ARE assertable in specs).
 
+## Live API mode (opt-in, separate project)
+
+The offline suite is the acceptance suite; live mode is a validation suite for
+Register's *usage* of the Reserve and zapper APIs, in its own `live` Playwright
+project (`pnpm e2e:live`, `@live` grep, 1 worker, no retries) that the smoke,
+full, and mobile projects exclude. It is off unless an env var names a target:
+`E2E_LIVE_RESERVE_API` and `E2E_LIVE_ZAPPER_API`, resolved independently by
+`helpers/live.ts` (`production` / `staging` / `zrs1` / an absolute URL; an
+unknown value throws rather than silently falling back offline).
+
+Design decisions worth keeping:
+
+- **One surface classifier, not a URL soup.** `surfaceForPath` owns the split —
+  `/api/zapper/**` and `/api/prices/**` are the zapper surface, everything else
+  is Reserve — so a planner deployment (zrs1) and api.reserve.org can be
+  validated in the same run.
+- **Live is a boundary swap, not an escape hatch.** `helpers/api.ts` consults the
+  live target *before* snapshots and overrides; everything else (default-deny
+  egress, `boundaryRequests` recording, teardown failure) is unchanged, and
+  `allowUnmocked` is still not a live toggle. Live responses are additionally
+  validated by `helpers/live-contracts.ts` — per-endpoint zod shapes plus
+  invariants (quote `minAmountOut <= amountOut`, non-zero `amountOut`, a `tx`
+  whenever funds suffice, candle `high >= low` and open/close within range).
+  Shape drift or a broken invariant fails the test.
+- **Everything non-API stays mocked**: RPC, subgraph, wallet, receipts, chain
+  state, and the CoW/velora/enso aggregators (explicit disabled 503 — the
+  planner zap is the provider under validation). So live UI specs are *hybrid*:
+  live API data joined to pinned chain state. When the live basket drifts from
+  the captured one the SDK can't join them, so `basketDrift` detects it and the
+  spec skips with a re-capture instruction instead of reporting a fake failure
+  or a fake pass.
+- **Bounded probing.** `/api/zapper/{chain}/tokens` is ~500 MB; `liveProbe`
+  reads a prefix and validates on that, never buffering the response.
+- **Teardown races are not violations.** `isTeardownRace` filters only
+  browser/page-closed messages from in-flight passthrough fetches; real
+  transport failures and timeouts remain contract violations.
+
+Coverage lives in `e2e/tests/live/` (contract specs for the Reserve and planner
+surfaces, plus live pricing and zap-widget UI specs); `e2e/README.md` § Live API
+mode is the operator guide, and the standing findings/limitations (token-list
+parser drift, planner price gaps, hybrid-basket drift, deploy being quote-level
+only) are in [[progress]] § E2E coverage debt.
+
 ## Transactions and time
 
 The injected EIP-6963/EIP-1193 provider records every send in the per-test
@@ -89,6 +132,8 @@ age, and DTF/chain identity.
 - `pnpm e2e:check`: manifest, identity, and freshness.
 - `pnpm e2e:capture:yield`: re-capture the yield RToken eth_call + subgraph maps.
 - `pnpm exec vitest run e2e/helpers/tests`: mock-contract unit tests.
+- `E2E_LIVE_ZAPPER_API=zrs1 pnpm e2e:live`: the opt-in live API validation
+  project (never runs in CI; needs egress to the target).
 
 CI uses pnpm, Node 24, current actions, and Chromium only. PR/push runs
 typecheck, the mock-contract unit tests, snapshot check, and smoke; nightly/

--- a/docs/wiki/progress.md
+++ b/docs/wiki/progress.md
@@ -1,6 +1,6 @@
 ---
 title: Progress
-updated: 2026-08-10
+updated: 2026-08-11
 type: ledger
 ---
 
@@ -10,6 +10,7 @@ Stage ledger. One row per stage; keep entries short. Verifier = exact fresh comm
 
 | Stage | Status | Verifier | Review | Next |
 |---|---|---|---|---|
+| Live API validation mode for the E2E suite (reserve + zapper/planner, zrs1) | human-review-required (base a6f20e340) | offline unchanged: typecheck · lint · 95 helper units (23 new) · smoke 58 · `e2e:check` · `E2E_LIVE_RESERVE_API=production E2E_LIVE_ZAPPER_API=zrs1 pnpm e2e:live` → 39 passed / 1 skipped (CMC20 basket drift) | self: default-deny, request recording and strict teardown unchanged; no `allowUnmocked`, no wildcard mocks; findings recorded, not asserted away | **Engineer review required**: deploy is quote-level only; token-list drift needs a client-or-API decision — § E2E coverage debt |
 | Preserve Index DTF section in cmd-k navigation | human-review-required (base ebcd6febe) | RED: proposal/rebalance both landed overview; GREEN 2/2 · gate typecheck/lint/880 unit · live Ctrl+K proposal→governance + rebalance→auctions | independent Intent + Engineering Risk PASS, no findings; shared route-selection behavior requires Engineer review | merge only after Engineer review; wiki-lint blocked by pre-existing stale design-system page |
 | vote modal: address-length title overflowed the dialog | done (base 6854a370b) | lint · typecheck · test:run · e2e helper units · smoke 58 · new `vote-modal-long-title` spec desktop+mobile green · RED-verified (reverted the index-dtf modal fix → checkbox right edge 943 vs dialog 849.9) | product/correctness: self — copy + layout only, no tx path touched | — |
 | Fix DTF settings confirm button | human-review-required (base 6854a370b) | RED: rounded seeded distribution blocked mandate confirm; GREEN: unit 878 incl. mapper 27/27 · focused E2E 5/5 · typecheck · lint | Dark HOLD on untested mapping → 27 exhaustive mapper tests → Dark PASS; Light PASS; CodeRabbit 2 Minor → resolved (test IDs + editable confirmed state) | PR #1084 open; Engineer review required before merge; wiki-lint blocked by pre-existing stale design-system page |
@@ -46,6 +47,30 @@ Stage ledger. One row per stage; keep entries short. Verifier = exact fresh comm
 ### E2E coverage debt (fail-loud workarounds to pay down)
 
 - **Index/Arbitrum egress assertion owed**: a spec inspecting `boundaryRequests` asserting NO Index-domain call carries chainId 42161 (with a Yield-positive counterpart — dtf-yield keeps Arbitrum). A green smoke does NOT prove this: teardown only fails on unmocked calls and the RPC mock answers Arbitrum generically.
+- **Live API mode findings + limits** (`pnpm e2e:live`, 2026-08-11 against
+  reserve=production, zapper=zrs1 — 39 passed / 1 skipped):
+  - **`fetchZapperTokens` cannot read any deployment's token list** (`src/utils/zapper.ts`):
+    it reads `data.tokens[]`, every deployment answers `{status, result[]}`, and
+    the helper's `catch` turns the mismatch into an empty Set — "no token is
+    zappable", silently. Pinned with `test.fail()` in
+    `tests/live/zapper-api-contract.spec.ts`. Fix = parse `result[]` (or align the
+    API) and drop the pin; needs a decision on which side moves.
+  - **The planner prices no PHOTON Ondo RWA token on BSC** (`/api/prices/56`
+    returns `result: []` for 9 basket tokens; the route doesn't exist on
+    api.reserve.org at all). Not a register bug today — register reads
+    `/current/prices`, which covers them — so the spec asserts exactly that
+    cross-surface guarantee: a planner gap must be covered by the Reserve API,
+    else the basket renders $0.
+  - **Live UI specs are hybrid** (live API + pinned chain state), so a real
+    basket change invalidates them: CMC20 skips because the live basket added
+    `0x2859e4544c4bb03966803b044a93563bd2d0dd4d` and the SDK can't join the two.
+    Pay down by re-capturing (`pnpm e2e:capture`) or by making the live UI specs
+    seed chain state from the live basket.
+  - **Deploy is quote-level only** — the planner's deploy/deploy-ungoverned tx is
+    validated as a contract, never submitted; on-chain deploy stays uncovered.
+  - **Aggregators are deliberately disabled in live mode** (CoW/velora/enso get an
+    explicit 503) so the planner is the provider under validation; live CoW
+    routing is therefore uncovered.
 - **Vote-lock (vlRSR) uncovered paths** (Codex review 2026-07-31): external Earn/portfolio drawer first-open (the hook-order crash path — fixed, untested); portfolio live-zero + RPC-error fallback branches; governance card rate/redeemable presentation; a legacy 1:1 vault through the universal redeem path (drawer spec only covers vlRSR); earn cell RPC-failure fallback (skeleton→1:1).
 
 A mock strict enough that a spec routes AROUND its gap silently shrinks the

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -190,6 +190,8 @@ Then follow the steps below to fill it in.
 ## Commands
 
 `pnpm e2e:smoke` (fast, per-diff) · `pnpm e2e:full` (flows) · `pnpm e2e` (both)
+· `E2E_LIVE_ZAPPER_API=zrs1 pnpm e2e:live` (opt-in live API validation — the
+`@live` project, never part of the offline suites; `e2e/README.md` § Live API mode)
 · `pnpm e2e:ui` (headed debug) · `pnpm exec vitest run e2e/helpers/tests`
 (mock contracts, fastest tier) · `pnpm e2e:check` / `pnpm e2e:capture` /
 `pnpm e2e:capture:yield` (snapshots).

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -63,6 +63,62 @@ default-denies any non-local request that is not explicitly modeled:
 shared by mocks, capture, and tests. `helpers/snapshots.ts` loads the
 `{_meta, data}` envelope from `snapshots/<chain>/<slug>/*.json`.
 
+## Live API mode (validating the real Reserve / zapper APIs)
+
+The committed suite is offline and stays that way. Live mode is a separate
+opt-in project (`pnpm e2e:live`, `@live`-tagged specs under `tests/live/`,
+excluded from smoke/full/mobile) that swaps ONLY the API boundary for a
+recording passthrough:
+
+```bash
+E2E_LIVE_ZAPPER_API=zrs1 pnpm e2e:live                       # planner surface only
+E2E_LIVE_RESERVE_API=production E2E_LIVE_ZAPPER_API=zrs1 pnpm e2e:live   # both
+```
+
+The two surfaces are independent env vars, each taking a named target or an
+absolute URL (anything else is a hard error, not a silent offline fallback):
+
+| Var | Targets | Surface (`surfaceForPath`) |
+|---|---|---|
+| `E2E_LIVE_RESERVE_API` | `production` (api.reserve.org), `staging`, `https://…` | everything except the two paths below |
+| `E2E_LIVE_ZAPPER_API` | `zrs1` (zrs-1.reserve-api.com), `production`, `staging`, `https://…` | `/api/zapper/**`, `/api/prices/**` |
+
+What live mode does and does not touch:
+
+- **Live**: the configured surface's HTTP responses, rewritten onto the target
+  origin, recorded in `boundaryRequests` exactly like a mocked call, and
+  validated against `helpers/live-contracts.ts` (zod shape + invariants:
+  `minAmountOut <= amountOut`, non-zero `amountOut`, a `tx` whenever funds are
+  sufficient, candle `high >= low`, open/close inside high/low). Drift fails the
+  test; the unmocked-egress default-deny is still in force.
+- **Still mocked, always**: RPC, subgraph, wallet, receipts, chain state, and
+  the CoW/velora/enso aggregators (an explicit disabled 503, so the planner zap
+  is the provider under validation). Chain state therefore stays pinned to the
+  committed snapshots — see the hybrid-test limitation below.
+
+Coverage: `tests/live/reserve-api-contract.spec.ts` and
+`zapper-api-contract.spec.ts` are request-level (no browser) and cover prices,
+current/historical DTF, candles, compliance, discover, portfolio, exposure,
+rebalance + liquidity, the zappable token lists, planner health, buy quotes and
+the ungoverned deploy quote. `pricing-live.spec.ts` and `zap-widget-live.spec.ts`
+drive the real UI against live responses.
+
+Limitations (all deliberate, tracked in `docs/wiki/progress.md` § E2E coverage debt):
+
+- **Hybrid tests can be invalidated by real basket changes.** The UI specs join
+  live API data with pinned chain state; when the live basket gains or loses a
+  token the SDK cannot join the two and the spec skips with a `basketDrift`
+  message telling you to run `pnpm e2e:capture`. It reports drift, it does not
+  paper over it.
+- **`/api/zapper/{chain}/tokens` is ~500 MB.** It is probed in bounded form
+  (`liveProbe`), never buffered.
+- **The token list is pinned as known drift**: `fetchZapperTokens` reads
+  `data.tokens[]`, every deployment answers `{status, result[]}`, and the
+  helper's catch-all turns that into "nothing is zappable" with no error. The
+  spec asserts the mismatch with `test.fail()`.
+- **Deploy is quote-level only.** On-chain deployment is not executed; the
+  deploy transaction the planner returns is not submitted to a real chain.
+
 ## Fail-loud philosophy
 
 Every mock that can't answer calls the logger (`[E2E] unmocked ...`). The base

--- a/e2e/TEST_MAP.md
+++ b/e2e/TEST_MAP.md
@@ -11,9 +11,11 @@ grep -rln "@mobile" e2e/tests                         # mobile-tagged specs
 
 Harness architecture (mock layer, trust contract, CI split) lives in
 `docs/wiki/domains/e2e.md`; mock mechanics and recipes live in `e2e/CLAUDE.md`.
-Playwright runs 3 projects (`playwright.config.ts`): **smoke** (`@smoke`-tagged,
+Playwright runs 4 projects (`playwright.config.ts`): **smoke** (`@smoke`-tagged,
 Desktop Chrome), **full** (everything else, Desktop Chrome), **mobile**
-(`@mobile`-tagged, Pixel 7 viewport — off CI, `pnpm e2e:mobile`).
+(`@mobile`-tagged, Pixel 7 viewport — off CI, `pnpm e2e:mobile`), and **live**
+(`@live`-tagged, opt-in, excluded from the other three — see § Live API
+validation).
 
 73 specs across 5 top-level dirs: `general/` (8), `index-dtf/` (17),
 `yield-dtf/` (6), `smoke/` (12), `flows/` (30). `index-dtf/` and `yield-dtf/`
@@ -96,6 +98,21 @@ additional state coverage: [boot](tests/smoke/boot.spec.ts) (home shell),
   lifecycle specs. The entire `flows/` directory (30 specs — all governance/
   auction/issuance write and edge-case behavior) and all of `smoke/` have zero
   `@mobile` coverage.
+
+## Live API validation (`tests/live/`, opt-in)
+
+Off by default; enabled per surface with `E2E_LIVE_RESERVE_API` /
+`E2E_LIVE_ZAPPER_API` and run with `pnpm e2e:live`. Not part of the offline
+coverage matrix above — these specs validate Register's API *usage* against a
+real deployment (zrs1 for the planner) and are excluded from smoke/full/mobile.
+Operator guide: `e2e/README.md` § Live API mode.
+
+| Surface | Spec | Covers | Not covered |
+|---|---|---|---|
+| Reserve API (request-level) | [live/reserve-api-contract](tests/live/reserve-api-contract.spec.ts) | `/current/prices`, `/current/dtf`, `/historical/prices`, `/historical/dtf` (+ v2 candles), compliance (geolocation, per-DTF, wallet), `/v1/discover/dtfs`, `/v1/portfolio/:address`, `/dtf/exposure`, `/dtf/rebalance`, `POST /rebalance/liquidity`, legacy `/zapper/tokens` | auth'd surfaces, write endpoints |
+| Zapper/planner (request-level) | [live/zapper-api-contract](tests/live/zapper-api-contract.spec.ts) | planner `health`, bounded `/api/zapper/{chain}/tokens` probe per chain, `/api/prices/{chain}` per basket (+ reserve-covers-the-gap cross-check), buy quotes per DTF, ungoverned deploy quote | sell quotes, governed deploy body variants, on-chain execution |
+| Pricing UI | [live/pricing-live](tests/live/pricing-live.spec.ts) | overview hero price + plotted chart geometry from live Reserve responses per registry DTF | any DTF whose live basket drifted from the captured chain state (skips with a re-capture instruction) |
+| Zap widget UI | [live/zap-widget-live](tests/live/zap-widget-live.spec.ts) | buy quote through the real widget on Base, submitted tx equals the live quote's `tx` (mocked wallet/receipts) | sell, other chains, real chain execution |
 
 ## Active fixmes (2)
 

--- a/e2e/fixtures/base.ts
+++ b/e2e/fixtures/base.ts
@@ -3,6 +3,7 @@ import { DEFAULT_GEOLOCATION, mockApiRoutes, type GeolocationStatus } from '../h
 import type { UnmockedLogger } from '../helpers/logger'
 import { MockOverrides } from '../helpers/overrides'
 import { resetFrozenTime } from '../helpers/clock'
+import { describeLiveConfig, isLiveMode, liveConfig, type LiveConfig } from '../helpers/live'
 import type { TxRecord } from '../helpers/provider'
 import type { BoundaryRequest } from '../helpers/requests'
 import { mockRpcRoutes, setMockNow, setYieldReplay } from '../helpers/rpc'
@@ -26,6 +27,15 @@ export interface BaseFixtures {
   // Every handled API/subgraph/RPC request. Tests use this to prove source,
   // identity, parameters, and request counts rather than only rendered shells.
   boundaryRequests: BoundaryRequest[]
+  // Live-API surfaces resolved from E2E_LIVE_RESERVE_API / E2E_LIVE_ZAPPER_API
+  // (helpers/live.ts). Empty object = the default fully-offline suite. Specs
+  // read it to skip when their target is not configured; the API mock reads it
+  // to pass a surface through to the real deployment.
+  live: LiveConfig
+  // Response-contract failures recorded by the live passthrough. Fails the test
+  // at teardown, exactly like `unmockedCalls` — a live run that quietly accepts
+  // a drifted payload would validate nothing.
+  liveViolations: string[]
   // Escape hatch for genuinely exploratory specs: when true, unmocked calls are
   // still logged/attached but don't fail the test. Default false — a committed
   // migration flow must fail on any unmocked RPC/API/subgraph/egress call.
@@ -43,6 +53,16 @@ async function fulfillEmpty(route: import('@playwright/test').Route, body: unkno
 export const test = base.extend<BaseFixtures>({
   compliance: [DEFAULT_GEOLOCATION, { option: true }],
   allowUnmocked: [false, { option: true }],
+
+  // oxlint-disable-next-line no-empty-pattern -- {} = no deps
+  live: async ({}, use) => {
+    await use(liveConfig())
+  },
+
+  // oxlint-disable-next-line no-empty-pattern -- {} = no deps
+  liveViolations: async ({}, use) => {
+    await use([])
+  },
 
   // Fresh per test — a new instance means overrides never leak between tests.
   // oxlint-disable-next-line no-empty-pattern -- Playwright derives fixture deps from the destructuring pattern; {} = no deps
@@ -63,7 +83,16 @@ export const test = base.extend<BaseFixtures>({
 
   unmockedCalls: [
     async (
-      { page, compliance, overrides, txLog, boundaryRequests, allowUnmocked },
+      {
+        page,
+        compliance,
+        overrides,
+        txLog,
+        boundaryRequests,
+        allowUnmocked,
+        live,
+        liveViolations,
+      },
       use,
       testInfo
     ) => {
@@ -122,7 +151,13 @@ export const test = base.extend<BaseFixtures>({
         geolocation: compliance,
         overrides,
         requests: boundaryRequests,
+        live,
+        liveViolations,
       })
+
+      if (isLiveMode(live)) {
+        console.log(`[E2E] live API mode: ${describeLiveConfig(live)}`)
+      }
 
       // WalletConnect / relay / explorer: fulfill empty (NOT abort) — connectors
       // init eagerly on mount and aborts surface unhandled rejections.
@@ -214,6 +249,18 @@ export const test = base.extend<BaseFixtures>({
       if (!allowUnmocked && calls.length) {
         throw new Error(
           `test hit ${calls.length} unmocked call(s):\n${calls.join('\n')}`
+        )
+      }
+
+      // Live contract drift is a failure of the deployment under validation —
+      // never a soft warning, and never silenced by allowUnmocked.
+      if (liveViolations.length) {
+        await testInfo.attach('live-contract-violations', {
+          body: liveViolations.join('\n'),
+          contentType: 'text/plain',
+        })
+        throw new Error(
+          `live API returned ${liveViolations.length} contract violation(s):\n${liveViolations.join('\n')}`
         )
       }
     },

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test'
+import { fulfillFromLive, surfaceForPath, type LiveConfig } from './live'
 import type { UnmockedLogger } from './logger'
 import type { MockOverrides } from './overrides'
 import type { BoundaryRequest } from './requests'
@@ -28,6 +29,11 @@ export interface ApiMockOptions {
   geolocation: GeolocationStatus
   overrides?: MockOverrides
   requests?: BoundaryRequest[]
+  // Live-API mode (helpers/live.ts). A surface with a target configured is
+  // passed through to the real deployment instead of being answered from
+  // snapshots; the other surface stays mocked. Empty/absent = fully offline.
+  live?: LiveConfig
+  liveViolations?: string[]
 }
 
 function json(route: import('@playwright/test').Route, data: unknown, status = 200) {
@@ -163,7 +169,7 @@ export function knownPriceResponse(
 }
 
 export async function mockApiRoutes(page: Page, options: ApiMockOptions) {
-  const { log, geolocation, overrides, requests } = options
+  const { log, geolocation, overrides, requests, live, liveViolations } = options
 
   const handler = async (route: Parameters<Parameters<Page['route']>[1]>[0]) => {
     const url = new URL(route.request().url())
@@ -177,6 +183,14 @@ export async function mockApiRoutes(page: Page, options: ApiMockOptions) {
       search: Object.fromEntries(url.searchParams),
     })
     await overrides?.holds.gate({ boundary: 'api', pathname: path })
+
+    // Live passthrough wins over BOTH snapshots and per-test overrides: a live
+    // run must report what the deployment actually returns, never a local
+    // substitute. Only the surfaces explicitly pointed at a target are live.
+    const liveTarget = live?.[surfaceForPath(path)]
+    if (liveTarget && liveViolations) {
+      return fulfillFromLive(route, liveTarget, { violations: liveViolations, log, requests })
+    }
 
     // Per-test overlay wins over snapshots — exact method/path plus any
     // identity-bearing query fields the spec supplies.

--- a/e2e/helpers/live-contracts.ts
+++ b/e2e/helpers/live-contracts.ts
@@ -1,0 +1,430 @@
+import { z } from 'zod'
+import type { LiveSurface } from './live'
+
+// Response contracts for every Reserve/zapper endpoint register consumes.
+//
+// In mocked runs the snapshots ARE the contract: a spec asserting a rendered
+// price proves register reads the shape it was captured against. A live run has
+// no such anchor — the upstream may return a different magnitude every call —
+// so the oracle becomes the SHAPE plus shape-only invariants: the parts register
+// actually depends on. A drifted field, a null where a number is required, or a
+// quote whose tx cannot execute is reported as a contract violation and fails
+// the live test.
+//
+// Sources of truth for each schema (keep in sync when they change):
+//   zapper surface — zapper/crates/public-api/src/models/{swap,price,tokens}.rs
+//                    and src/views/yield-dtf/issuance/components/zapV2/api
+//   reserve surface — the consuming hooks in src/hooks + src/views (each entry
+//                     names the consumer whose expectations it encodes)
+
+const addressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'not an address')
+const weiSchema = z.string().regex(/^\d+$/, 'not a base-10 wei string')
+const hexDataSchema = z.string().regex(/^0x([0-9a-fA-F]{2})*$/, 'not hex calldata')
+
+// ---------------------------------------------------------------------------
+// Zapper surface (planner)
+// ---------------------------------------------------------------------------
+
+const zapResultSchema = z
+  .object({
+    tokenIn: addressSchema,
+    tokenOut: addressSchema,
+    amountIn: weiSchema,
+    amountOut: weiSchema,
+    minAmountOut: weiSchema.optional(),
+    // Empty when the planner built no route to approve against; that is a
+    // defect only when an approval is actually needed (invariant below).
+    approvalAddress: z.union([addressSchema, z.literal('')]),
+    approvalNeeded: z.boolean(),
+    insufficientFunds: z.boolean(),
+    dust: z.array(z.object({ token: z.string(), amount: z.string() })),
+    dustValue: z.number().nullable().optional(),
+    amountInValue: z.number().nullable().optional(),
+    amountOutValue: z.number().nullable().optional(),
+    gas: z.string().nullable().optional(),
+    priceImpact: z.number(),
+    truePriceImpact: z.number(),
+    // Absent/null on a quote the planner could not encode. Whether that is
+    // legal for THIS quote is an invariant, not a shape question.
+    tx: z
+      .object({ data: hexDataSchema, to: addressSchema, value: z.string() })
+      .nullish(),
+  })
+  .loose()
+
+const zapResponseSchema = z
+  .object({
+    status: z.enum(['success', 'error']),
+    result: zapResultSchema.optional(),
+    error: z.string().optional(),
+  })
+  .loose()
+
+// Invariants register's zap UI relies on (useZapSwapQuery + the react-zapper
+// widget): a successful quote must be executable and must move a non-zero
+// amount, otherwise the panel shows an output it cannot submit.
+function zapQuoteInvariants(data: unknown): string[] {
+  const parsed = zapResponseSchema.safeParse(data)
+  if (!parsed.success) return []
+  const quote = parsed.data
+  if (quote.status !== 'success' || !quote.result) return []
+  const result = quote.result
+  const issues: string[] = []
+
+  if (BigInt(result.amountOut) === 0n) issues.push('successful quote has amountOut = 0')
+  if (!result.insufficientFunds && !result.tx) {
+    issues.push('successful quote with sufficient funds has no tx to submit')
+  }
+  if (result.approvalNeeded && !result.approvalAddress) {
+    issues.push('quote needs an approval but carries no approvalAddress')
+  }
+  if (result.minAmountOut && BigInt(result.minAmountOut) > BigInt(result.amountOut)) {
+    // The on-chain floor above the expected output means the built tx would
+    // revert INSUFFICIENT_OUT (see ZapResponse.min_amount_out in the planner).
+    issues.push(
+      `minAmountOut (${result.minAmountOut}) exceeds amountOut (${result.amountOut}) — tx would revert INSUFFICIENT_OUT`
+    )
+  }
+  if (result.priceImpact < 0) issues.push(`priceImpact is negative (${result.priceImpact})`)
+  return issues
+}
+
+const plannerTokenSchema = z
+  .object({
+    address: addressSchema,
+    symbol: z.string(),
+    name: z.string(),
+    decimals: z.number().int().min(0).max(36),
+  })
+  .loose()
+
+// Zappable token list. Two element shapes are in the wild and both are
+// accepted here, because the endpoint's own envelope is what this contract
+// covers: api.reserve.org returns `{ token: {...}, liquidity }` entries, the
+// zrs1 planner returns the flat token. NOTE: neither is what
+// src/utils/zapper.ts fetchZapperTokens reads (`data.tokens[]`) — that drift is
+// asserted, and its consequence documented, in tests/live/zapper-api-contract.
+const plannerTokensSchema = z
+  .object({
+    status: z.enum(['success', 'error']),
+    result: z
+      .array(
+        z.union([
+          plannerTokenSchema,
+          z.object({ token: plannerTokenSchema, liquidity: z.number().nullable() }).loose(),
+        ])
+      )
+      .optional(),
+  })
+  .loose()
+
+const plannerPricesSchema = z
+  .object({
+    status: z.enum(['success', 'error']),
+    result: z
+      .array(
+        z.object({
+          address: addressSchema,
+          symbol: z.string(),
+          price: z.number(),
+          source: z.string().optional(),
+        })
+      )
+      .optional(),
+  })
+  .loose()
+
+// ---------------------------------------------------------------------------
+// Reserve surface (reserve-api)
+// ---------------------------------------------------------------------------
+
+// hooks/usePrices.ts + views/index-dtf/deploy/updater.tsx: [{ address, price }].
+const currentPricesSchema = z.array(
+  z
+    .object({
+      address: addressSchema,
+      price: z.number().nullable().optional(),
+      timestamp: z.number().optional(),
+    })
+    .loose()
+)
+
+// hooks/useIndexPrice.ts reads `price`; the DTF endpoints echo identity.
+const currentDtfSchema = z
+  .object({ address: addressSchema.optional(), price: z.number().nullable().optional() })
+  .loose()
+
+const timeseriesSchema = z
+  .object({
+    address: addressSchema.optional(),
+    timeseries: z.array(z.object({ timestamp: z.number() }).loose()),
+  })
+  .loose()
+
+// /v2/historical/dtf/candles — the overview's DEFAULT chart type, and a
+// different shape from the line-chart timeseries above.
+const candlesSchema = z
+  .object({
+    address: addressSchema.optional(),
+    candles: z.array(
+      z
+        .object({
+          timestamp: z.number(),
+          open: z.number(),
+          high: z.number(),
+          low: z.number(),
+          close: z.number(),
+        })
+        .loose()
+    ),
+  })
+  .loose()
+
+// A candle whose high/low do not bracket its open/close cannot be drawn as a
+// candle body inside its wick (candlestick-chart-body.tsx).
+function candleInvariants(data: unknown): string[] {
+  const parsed = candlesSchema.safeParse(data)
+  if (!parsed.success) return []
+  const issues: string[] = []
+  for (const candle of parsed.data.candles) {
+    if (candle.high < candle.low) {
+      issues.push(`candle ${candle.timestamp}: high (${candle.high}) < low (${candle.low})`)
+    }
+    if (
+      Math.max(candle.open, candle.close) > candle.high ||
+      Math.min(candle.open, candle.close) < candle.low
+    ) {
+      issues.push(`candle ${candle.timestamp}: open/close outside the high/low range`)
+    }
+    if (issues.length >= 3) break // one failure is enough; don't dump the series
+  }
+  return issues
+}
+
+const geolocationSchema = z
+  .object({
+    country: z.string(),
+    countryCode: z.string(),
+    restricted: z.boolean(),
+  })
+  .loose()
+
+// hooks/use-dtf-restricted.ts fail-CLOSES on a bad shape — a drift here silently
+// gates every DTF surface in production, so it is contracted explicitly.
+const dtfComplianceSchema = z
+  .object({ restricted: z.boolean(), restriction: z.string().optional() })
+  .loose()
+
+const walletComplianceSchema = z.object({ isRestricted: z.boolean() }).loose()
+
+const discoverSchema = z.array(
+  z.object({ address: addressSchema, chainId: z.number() }).loose()
+)
+
+const portfolioSchema = z
+  .object({
+    totalHoldingsUSD: z.number(),
+    indexDTFs: z.array(z.unknown()),
+    yieldDTFs: z.array(z.unknown()),
+  })
+  .loose()
+
+const healthSchema = z.looseObject({})
+
+// ---------------------------------------------------------------------------
+// Contract registry
+// ---------------------------------------------------------------------------
+
+export interface LiveContract {
+  name: string
+  surface: LiveSurface
+  match: (method: string, url: URL) => boolean
+  schema: z.ZodType
+  invariants?: (data: unknown) => string[]
+  // Endpoints whose documented behavior includes a non-2xx answer (an
+  // unroutable zap is a 4xx/5xx with an error body, not a broken deployment).
+  allowedErrorStatuses?: number[]
+}
+
+const get = (method: string) => method === 'GET'
+
+export const LIVE_CONTRACTS: LiveContract[] = [
+  {
+    name: 'zap quote',
+    surface: 'zapper',
+    match: (m, u) => get(m) && /^\/api\/zapper\/\d+\/swap$/.test(u.pathname),
+    schema: zapResponseSchema,
+    invariants: zapQuoteInvariants,
+    allowedErrorStatuses: [400, 422, 500],
+  },
+  {
+    name: 'zap deploy',
+    surface: 'zapper',
+    match: (m, u) =>
+      m === 'POST' && /^\/api\/zapper\/\d+\/deploy(-ungoverned)?$/.test(u.pathname),
+    schema: zapResponseSchema,
+    invariants: zapQuoteInvariants,
+    allowedErrorStatuses: [400, 422, 500],
+  },
+  {
+    name: 'planner token list',
+    surface: 'zapper',
+    match: (m, u) => get(m) && /^\/api\/zapper\/\d+\/tokens$/.test(u.pathname),
+    schema: plannerTokensSchema,
+  },
+  {
+    name: 'planner prices',
+    surface: 'zapper',
+    match: (m, u) => get(m) && /^\/api\/prices\/\d+/.test(u.pathname),
+    schema: plannerPricesSchema,
+  },
+  {
+    name: 'current prices',
+    surface: 'reserve',
+    match: (m, u) => get(m) && u.pathname.endsWith('/current/prices'),
+    schema: currentPricesSchema,
+  },
+  {
+    name: 'current dtf',
+    surface: 'reserve',
+    match: (m, u) => get(m) && u.pathname.endsWith('/current/dtf'),
+    schema: currentDtfSchema,
+  },
+  {
+    name: 'historical dtf candles',
+    surface: 'reserve',
+    match: (m, u) => get(m) && u.pathname.includes('/historical/dtf/candles'),
+    schema: candlesSchema,
+    invariants: candleInvariants,
+  },
+  {
+    name: 'historical dtf',
+    surface: 'reserve',
+    match: (m, u) =>
+      get(m) &&
+      u.pathname.includes('/historical/dtf') &&
+      !u.pathname.includes('/candles'),
+    schema: timeseriesSchema,
+  },
+  {
+    name: 'historical prices',
+    surface: 'reserve',
+    match: (m, u) => get(m) && u.pathname.includes('/historical/prices'),
+    schema: timeseriesSchema,
+  },
+  {
+    name: 'dtf exposure',
+    surface: 'reserve',
+    match: (m, u) => get(m) && u.pathname.includes('/dtf/exposure'),
+    schema: z.union([z.array(z.unknown()), z.looseObject({})]),
+  },
+  {
+    name: 'dtf compliance',
+    surface: 'reserve',
+    match: (m, u) => get(m) && u.pathname.includes('/v2/compliance/geolocation/dtf/'),
+    schema: dtfComplianceSchema,
+  },
+  {
+    name: 'geolocation compliance',
+    surface: 'reserve',
+    match: (m, u) =>
+      get(m) &&
+      u.pathname.includes('/v2/compliance/geolocation') &&
+      !u.pathname.includes('/dtf/'),
+    schema: geolocationSchema,
+  },
+  {
+    name: 'wallet compliance',
+    surface: 'reserve',
+    match: (m, u) => get(m) && u.pathname.includes('/v2/compliance/wallet/'),
+    schema: walletComplianceSchema,
+  },
+  {
+    name: 'discover dtfs',
+    surface: 'reserve',
+    match: (m, u) => get(m) && /\/discover\/(dtfs?|featured)$/.test(u.pathname),
+    schema: discoverSchema,
+  },
+  {
+    name: 'portfolio',
+    surface: 'reserve',
+    match: (m, u) =>
+      get(m) && /\/v1\/portfolio\/0x[a-fA-F0-9]{40}$/.test(u.pathname),
+    schema: portfolioSchema,
+  },
+  {
+    // hooks/use-token-list.ts — reserve-api's OWN list (a flat array with a
+    // volatility classification), not the planner's envelope.
+    name: 'reserve zappable tokens',
+    surface: 'reserve',
+    match: (m, u) => get(m) && u.pathname.endsWith('/zapper/tokens'),
+    schema: z.array(
+      z.object({ address: addressSchema, symbol: z.string(), decimals: z.number() }).loose()
+    ),
+  },
+  {
+    name: 'health',
+    surface: 'zapper',
+    match: (m, u) => get(m) && u.pathname === '/health',
+    schema: healthSchema,
+  },
+]
+
+export function contractFor(
+  surface: LiveSurface,
+  method: string,
+  url: URL
+): LiveContract | undefined {
+  return LIVE_CONTRACTS.find(
+    (contract) => contract.surface === surface && contract.match(method, url)
+  )
+}
+
+export interface LiveValidationInput {
+  surface: LiveSurface
+  targetName: string
+  method: string
+  url: URL
+  status: number
+  body: string
+  postData?: string
+}
+
+function formatIssues(error: z.ZodError): string {
+  return error.issues
+    .slice(0, 5)
+    .map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`)
+    .join('; ')
+}
+
+// Validate one live response. Returns violation lines (empty = contract held).
+// An endpoint with no contract is NOT a violation — it is simply uncontracted;
+// the contract specs assert coverage of the endpoints register depends on.
+export function validateLiveResponse(input: LiveValidationInput): string[] {
+  const { surface, targetName, method, url, status, body } = input
+  const contract = contractFor(surface, method, url)
+  if (!contract) return []
+
+  const where = `${contract.name} [${method} ${targetName}${url.pathname}]`
+  const violations: string[] = []
+
+  if (status >= 400 && !contract.allowedErrorStatuses?.includes(status)) {
+    return [`${where} returned HTTP ${status}: ${body.slice(0, 200)}`]
+  }
+
+  let data: unknown
+  try {
+    data = JSON.parse(body)
+  } catch {
+    return [`${where} returned non-JSON body: ${body.slice(0, 200)}`]
+  }
+
+  const parsed = contract.schema.safeParse(data)
+  if (!parsed.success) {
+    violations.push(`${where} shape drifted — ${formatIssues(parsed.error)}`)
+  }
+  for (const issue of contract.invariants?.(data) ?? []) {
+    violations.push(`${where} ${issue}`)
+  }
+  return violations
+}

--- a/e2e/helpers/live.ts
+++ b/e2e/helpers/live.ts
@@ -1,0 +1,370 @@
+import type { APIRequestContext, Route } from '@playwright/test'
+import type { UnmockedLogger } from './logger'
+import { validateLiveResponse } from './live-contracts'
+import type { BoundaryRequest } from './requests'
+
+// Live-API mode — the ONLY seam where an e2e run talks to a real Reserve/zapper
+// deployment. Default (no env vars) is unchanged: every boundary is mocked and
+// external egress is denied.
+//
+// Two INDEPENDENT surfaces, mirroring src/utils/constants.ts (RESERVE_API vs
+// ZAPPER_API) and the actual deployments behind them:
+//
+//   zapper  — /api/zapper/** and /api/prices/**. Served by the Rust
+//             public-api (the "planner"): swap quotes, deploy zaps, the
+//             zappable token list, upstream token pricing.
+//   reserve — everything else on api.reserve.org: /current/*, /historical/*,
+//             /dtf/*, /v1/*, /v2/*, the velora|enso aggregator proxies.
+//             Served by reserve-api (Fastify), which proxies the zapper
+//             surface upstream.
+//
+// Split matters for zrs1: https://zrs-1.reserve-api.com IS a planner
+// deployment, so it serves the zapper surface (and /api/prices) but returns 404
+// for reserve-api's own endpoints. Point the zapper surface at zrs1 and the
+// reserve surface at production/staging to validate both in one run.
+//
+//   E2E_LIVE_ZAPPER_API=zrs1 pnpm e2e:live
+//   E2E_LIVE_ZAPPER_API=zrs1 E2E_LIVE_RESERVE_API=production pnpm e2e:live
+//   E2E_LIVE_RESERVE_API=https://my-branch.example.com pnpm e2e:live
+//
+// Requests are rewritten at the Playwright route boundary (origin swap, path +
+// query preserved), fetched from Node, validated against the per-endpoint
+// contracts in live-contracts.ts, and fulfilled back into the page. RPC,
+// subgraph and wallet stay mocked, so chain state remains deterministic while
+// the API boundary is real.
+
+export type LiveSurface = 'reserve' | 'zapper'
+
+export const LIVE_TARGETS: Record<string, string> = {
+  zrs1: 'https://zrs-1.reserve-api.com',
+  production: 'https://api.reserve.org',
+  staging: 'https://api-staging.reserve.org',
+}
+
+export const LIVE_ENV_VARS: Record<LiveSurface, string> = {
+  reserve: 'E2E_LIVE_RESERVE_API',
+  zapper: 'E2E_LIVE_ZAPPER_API',
+}
+
+// Live upstreams are slower and less predictable than a mock: a cold zappable
+// token list or a deep-liquidity quote can take tens of seconds.
+export const LIVE_REQUEST_TIMEOUT = 60_000
+
+export interface LiveTarget {
+  surface: LiveSurface
+  // Named target (`zrs1`) or `custom` for an explicit URL.
+  name: string
+  // Origin without a trailing slash.
+  base: string
+}
+
+export type LiveConfig = Partial<Record<LiveSurface, LiveTarget>>
+
+// Resolve one surface's env value: a named target or an absolute http(s) URL.
+// A typo must fail loudly — silently falling back to mocks would report a green
+// "live" run that never left the machine.
+export function resolveLiveTarget(
+  surface: LiveSurface,
+  value: string | undefined
+): LiveTarget | undefined {
+  const raw = value?.trim()
+  if (!raw) return undefined
+
+  const named = LIVE_TARGETS[raw]
+  if (named) return { surface, name: raw, base: named }
+
+  if (/^https?:\/\//.test(raw)) {
+    const url = new URL(raw)
+    return { surface, name: 'custom', base: url.origin }
+  }
+
+  throw new Error(
+    `${LIVE_ENV_VARS[surface]}="${raw}" is not a known target. Use one of ` +
+      `${Object.keys(LIVE_TARGETS).join(', ')} or an absolute http(s) URL.`
+  )
+}
+
+export function liveConfig(env: Record<string, string | undefined> = process.env): LiveConfig {
+  const config: LiveConfig = {}
+  for (const surface of ['reserve', 'zapper'] as const) {
+    const target = resolveLiveTarget(surface, env[LIVE_ENV_VARS[surface]])
+    if (target) config[surface] = target
+  }
+  return config
+}
+
+export function isLiveMode(config: LiveConfig = liveConfig()): boolean {
+  return Boolean(config.reserve || config.zapper)
+}
+
+export function describeLiveConfig(config: LiveConfig): string {
+  const parts = (['reserve', 'zapper'] as const)
+    .map((surface) => {
+      const target = config[surface]
+      return target ? `${surface}=${target.name} (${target.base})` : `${surface}=mocked`
+    })
+  return parts.join(', ')
+}
+
+// Which deployment owns a path. The planner surface is prefix-identified; the
+// rest of api.reserve.org belongs to reserve-api.
+export function surfaceForPath(pathname: string): LiveSurface {
+  return pathname.startsWith('/api/zapper/') || pathname.startsWith('/api/prices/')
+    ? 'zapper'
+    : 'reserve'
+}
+
+// Origin swap only — path and query are register's, and that is exactly what is
+// under validation.
+export function liveUrl(url: URL, target: LiveTarget): string {
+  return `${target.base}${url.pathname}${url.search}`
+}
+
+export interface LivePassthroughOptions {
+  // Contract failures, appended as human-readable lines. The base fixture fails
+  // the test at teardown when non-empty (same contract as `unmockedCalls`).
+  violations: string[]
+  log?: UnmockedLogger
+  requests?: BoundaryRequest[]
+}
+
+function violation(violations: string[], line: string) {
+  const message = `[E2E] live contract ${line}`
+  violations.push(message)
+  console.error(message)
+}
+
+// Browser-facing headers for a fulfilled live response. The upstream's CORS
+// headers are for app.reserve.org, not 127.0.0.1:3005, and content-encoding /
+// content-length would describe the already-decoded body.
+function fulfillHeaders(): Record<string, string> {
+  return {
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': '*',
+    'access-control-allow-methods': 'GET,POST,OPTIONS',
+    'cache-control': 'no-store',
+  }
+}
+
+// A page closing with live requests still in flight is not a target failure:
+// the fetch is abandoned (or its response disposed with the context), nobody
+// consumes it, and the spec's assertions already ran. Only real
+// transport/timeout failures are violations.
+export function isTeardownRace(message: string): boolean {
+  return /has been closed|has been disposed|Target closed|Test ended/.test(message)
+}
+
+// Fetch one request from the live target, validate it, and fulfill the page.
+export async function fulfillFromLive(
+  route: Route,
+  target: LiveTarget,
+  options: LivePassthroughOptions
+): Promise<void> {
+  const request = route.request()
+  const method = request.method()
+  const url = new URL(request.url())
+
+  // Cross-origin JSON POSTs (deploy zaps) preflight. The mock boundary never
+  // saw one; answer it locally so the real POST can go out.
+  if (method === 'OPTIONS') {
+    return route.fulfill({ status: 204, headers: fulfillHeaders(), body: '' })
+  }
+
+  const liveTarget = liveUrl(url, target)
+  let status: number
+  let body: string
+  let contentType: string
+  try {
+    const response = await route.fetch({
+      url: liveTarget,
+      timeout: LIVE_REQUEST_TIMEOUT,
+      maxRedirects: 5,
+    })
+    status = response.status()
+    body = await response.text()
+    contentType = response.headers()['content-type'] ?? 'application/json'
+  } catch (error) {
+    const message = (error as Error).message
+    if (isTeardownRace(message)) return
+    violation(
+      options.violations,
+      `${method} ${target.name}${url.pathname} request failed: ${message}`
+    )
+    return route.fulfill({
+      status: 599,
+      headers: { ...fulfillHeaders(), 'content-type': 'application/json' },
+      body: JSON.stringify({ error: '[E2E] live request failed' }),
+    })
+  }
+
+  for (const line of validateLiveResponse({
+    surface: target.surface,
+    targetName: target.name,
+    method,
+    url,
+    status,
+    body,
+    postData: request.postData() ?? undefined,
+  })) {
+    violation(options.violations, line)
+  }
+
+  // Live requests are recorded on the same boundary log as mocked ones, so a
+  // live spec can assert request identity/parameters exactly like an offline
+  // one (helpers/requests.ts).
+  options.requests?.push({
+    boundary: 'api',
+    method,
+    pathname: url.pathname,
+    search: Object.fromEntries(url.searchParams),
+  })
+
+  return route.fulfill({
+    status,
+    headers: { ...fulfillHeaders(), 'content-type': contentType },
+    body,
+  })
+}
+
+// Hybrid mode's one structural limitation. The API surface is live (today's
+// basket) while chain state stays pinned at the last `pnpm e2e:capture`, and the
+// SDK joins the two by token address: a token the deployment reports but the
+// mocked chain has never heard of leaves the DTF header/chart on its skeleton
+// forever (reproduced offline by injecting an extra basket token). A UI live spec
+// checks the two baskets first so drift reports itself instead of timing out.
+export interface BasketDrift {
+  // Addresses (lowercase) the live API reports and the snapshot does not.
+  added: string[]
+  // Addresses the snapshot has and the live API no longer reports.
+  removed: string[]
+}
+
+function basketAddresses(payload: unknown): string[] {
+  if (typeof payload !== 'object' || payload === null) return []
+  const basket = (payload as { basket?: unknown }).basket
+  if (!Array.isArray(basket)) return []
+  return basket
+    .map((token) =>
+      typeof token === 'object' && token !== null
+        ? (token as { address?: unknown }).address
+        : undefined
+    )
+    .filter((address): address is string => typeof address === 'string')
+    .map((address) => address.toLowerCase())
+}
+
+export function basketDrift(snapshot: unknown, live: unknown): BasketDrift {
+  const pinned = new Set(basketAddresses(snapshot))
+  const current = new Set(basketAddresses(live))
+  return {
+    added: [...current].filter((address) => !pinned.has(address)),
+    removed: [...pinned].filter((address) => !current.has(address)),
+  }
+}
+
+export function describeBasketDrift(drift: BasketDrift): string[] {
+  return [
+    ...drift.added.map((address) => `+${address}`),
+    ...drift.removed.map((address) => `-${address}`),
+  ]
+}
+
+// Request-level live validation for the contract specs (no browser involved).
+// Returns the parsed body so a spec can assert request-correlated invariants
+// (e.g. "every token I asked for came back priced").
+export async function liveGet(
+  request: APIRequestContext,
+  target: LiveTarget,
+  path: string,
+  violations: string[]
+): Promise<{ status: number; body: string; data: unknown }> {
+  return liveRequest(request, target, 'GET', path, violations)
+}
+
+export async function livePost(
+  request: APIRequestContext,
+  target: LiveTarget,
+  path: string,
+  payload: unknown,
+  violations: string[]
+): Promise<{ status: number; body: string; data: unknown }> {
+  return liveRequest(request, target, 'POST', path, violations, payload)
+}
+
+// Size-bounded probe for endpoints whose full body is impractical to buffer.
+// The zappable token list is the case that forced this: zrs1's Base list is
+// ~500 MB of JSON, so validating it means reading the head of the stream and
+// aborting, not parsing the document.
+export async function liveProbe(
+  target: LiveTarget,
+  path: string,
+  maxBytes = 64 * 1024
+): Promise<{ status: number; head: string; truncated: boolean; bytes: number }> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), LIVE_REQUEST_TIMEOUT)
+  try {
+    const response = await fetch(`${target.base}${path}`, { signal: controller.signal })
+    const reader = response.body?.getReader()
+    if (!reader) return { status: response.status, head: '', truncated: false, bytes: 0 }
+
+    const chunks: Uint8Array[] = []
+    let bytes = 0
+    let truncated = false
+    while (bytes < maxBytes) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+      bytes += value.byteLength
+      if (bytes >= maxBytes) truncated = true
+    }
+    await reader.cancel().catch(() => {})
+    return {
+      status: response.status,
+      head: Buffer.concat(chunks).toString('utf8'),
+      truncated,
+      bytes,
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function liveRequest(
+  request: APIRequestContext,
+  target: LiveTarget,
+  method: 'GET' | 'POST',
+  path: string,
+  violations: string[],
+  payload?: unknown
+): Promise<{ status: number; body: string; data: unknown }> {
+  const url = new URL(`${target.base}${path}`)
+  const response =
+    method === 'GET'
+      ? await request.get(url.toString(), { timeout: LIVE_REQUEST_TIMEOUT })
+      : await request.post(url.toString(), {
+          timeout: LIVE_REQUEST_TIMEOUT,
+          data: payload ?? {},
+        })
+
+  const status = response.status()
+  const body = await response.text()
+  for (const line of validateLiveResponse({
+    surface: target.surface,
+    targetName: target.name,
+    method,
+    url,
+    status,
+    body,
+    postData: payload === undefined ? undefined : JSON.stringify(payload),
+  })) {
+    violation(violations, line)
+  }
+
+  let data: unknown
+  try {
+    data = JSON.parse(body)
+  } catch {
+    data = undefined
+  }
+  return { status, body, data }
+}

--- a/e2e/helpers/tests/live.test.ts
+++ b/e2e/helpers/tests/live.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it } from 'vitest'
+import { validateLiveResponse } from '../live-contracts'
+import {
+  basketDrift,
+  describeBasketDrift,
+  describeLiveConfig,
+  isLiveMode,
+  isTeardownRace,
+  LIVE_ENV_VARS,
+  LIVE_TARGETS,
+  liveConfig,
+  liveUrl,
+  resolveLiveTarget,
+  surfaceForPath,
+  type LiveSurface,
+  type LiveTarget,
+} from '../live'
+
+// Contract tests for the live-API seam. The expensive property is the DEFAULT:
+// with no env vars set the suite must stay fully mocked, and a typo must never
+// degrade into "silently offline but reported as live".
+
+const zapperTarget: LiveTarget = {
+  surface: 'zapper',
+  name: 'zrs1',
+  base: LIVE_TARGETS.zrs1,
+}
+
+function url(path: string): URL {
+  return new URL(`https://api.reserve.org${path}`)
+}
+
+describe('live target resolution', () => {
+  it('is off by default — an empty env yields no live surface', () => {
+    const config = liveConfig({})
+    expect(config).toEqual({})
+    expect(isLiveMode(config)).toBe(false)
+  })
+
+  it('treats empty and whitespace-only values as off', () => {
+    expect(isLiveMode(liveConfig({ [LIVE_ENV_VARS.zapper]: '' }))).toBe(false)
+    expect(isLiveMode(liveConfig({ [LIVE_ENV_VARS.reserve]: '   ' }))).toBe(false)
+  })
+
+  it('resolves named targets per surface', () => {
+    const config = liveConfig({
+      [LIVE_ENV_VARS.zapper]: 'zrs1',
+      [LIVE_ENV_VARS.reserve]: 'production',
+    })
+    expect(config.zapper).toEqual({ surface: 'zapper', name: 'zrs1', base: LIVE_TARGETS.zrs1 })
+    expect(config.reserve?.base).toBe(LIVE_TARGETS.production)
+    expect(isLiveMode(config)).toBe(true)
+  })
+
+  it('accepts an absolute URL and keeps only its origin', () => {
+    const target = resolveLiveTarget('reserve', 'https://my-branch.example.com/base/path')
+    expect(target).toEqual({
+      surface: 'reserve',
+      name: 'custom',
+      base: 'https://my-branch.example.com',
+    })
+  })
+
+  it('throws on an unknown target instead of falling back to mocks', () => {
+    expect(() => resolveLiveTarget('zapper', 'zrs-1')).toThrow(/not a known target/)
+    expect(() => liveConfig({ [LIVE_ENV_VARS.zapper]: 'staging1' })).toThrow(
+      /E2E_LIVE_ZAPPER_API/
+    )
+  })
+
+  it('describes which surfaces are live and which stay mocked', () => {
+    const description = describeLiveConfig(liveConfig({ [LIVE_ENV_VARS.zapper]: 'zrs1' }))
+    expect(description).toContain('reserve=mocked')
+    expect(description).toContain('zapper=zrs1')
+  })
+})
+
+describe('surface classification', () => {
+  it('routes the planner paths to the zapper surface', () => {
+    expect(surfaceForPath('/api/zapper/8453/swap')).toBe('zapper')
+    expect(surfaceForPath('/api/zapper/8453/deploy-ungoverned')).toBe('zapper')
+    expect(surfaceForPath('/api/zapper/1/tokens')).toBe('zapper')
+    expect(surfaceForPath('/api/prices/56')).toBe('zapper')
+  })
+
+  it('routes everything else to the reserve surface', () => {
+    for (const path of [
+      '/current/prices',
+      '/current/dtf',
+      '/historical/dtf',
+      '/v1/portfolio/0x0',
+      '/v2/compliance/geolocation',
+      '/zapper/tokens',
+      '/velora/swap',
+    ]) {
+      expect(surfaceForPath(path), path).toBe('reserve')
+    }
+  })
+
+  it('rewrites only the origin, preserving path and query', () => {
+    expect(liveUrl(url('/api/zapper/8453/swap?chainId=8453&trade=true'), zapperTarget)).toBe(
+      `${LIVE_TARGETS.zrs1}/api/zapper/8453/swap?chainId=8453&trade=true`
+    )
+  })
+})
+
+describe('response contract validation', () => {
+  const validate = (
+    path: string,
+    body: unknown,
+    {
+      method = 'GET',
+      status = 200,
+      surface = 'zapper',
+    }: { method?: string; status?: number; surface?: LiveSurface } = {}
+  ) =>
+    validateLiveResponse({
+      surface,
+      targetName: 'zrs1',
+      method,
+      url: url(path),
+      status,
+      body: typeof body === 'string' ? body : JSON.stringify(body),
+    })
+
+  const quote = {
+    status: 'success',
+    result: {
+      tokenIn: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+      tokenOut: '0x4dA9A0f397dB1397902070f93a4D6ddBC0E0E6e8',
+      amountIn: '50000000000000000',
+      amountOut: '17905950155437571976',
+      minAmountOut: '17726890653883196256',
+      approvalAddress: '0x47A32430f7440395b17C7De7C32266A6d4E39d0A',
+      approvalNeeded: false,
+      insufficientFunds: false,
+      dust: [],
+      dustValue: 0,
+      priceImpact: 0.4,
+      truePriceImpact: -0.2,
+      tx: { data: '0xabcd', to: '0x47A32430f7440395b17C7De7C32266A6d4E39d0A', value: '0' },
+    },
+  }
+
+  it('accepts a real zap quote', () => {
+    expect(validate('/api/zapper/8453/swap', quote)).toEqual([])
+  })
+
+  it('accepts a negative truePriceImpact (signed by design)', () => {
+    expect(
+      validate('/api/zapper/8453/swap', {
+        ...quote,
+        result: { ...quote.result, truePriceImpact: -12.5 },
+      })
+    ).toEqual([])
+  })
+
+  it('flags a quote whose floor exceeds its expected output', () => {
+    const violations = validate('/api/zapper/8453/swap', {
+      ...quote,
+      result: { ...quote.result, minAmountOut: '20000000000000000000' },
+    })
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toContain('INSUFFICIENT_OUT')
+  })
+
+  it('flags a zero-output success and a success with no tx', () => {
+    expect(
+      validate('/api/zapper/8453/swap', {
+        ...quote,
+        result: { ...quote.result, amountOut: '0', minAmountOut: '0' },
+      })[0]
+    ).toContain('amountOut = 0')
+    expect(
+      validate('/api/zapper/8453/swap', { ...quote, result: { ...quote.result, tx: null } })[0]
+    ).toContain('no tx to submit')
+    // Observed on zrs1: `tx` omitted entirely rather than nulled.
+    const { tx: _tx, ...noTx } = quote.result
+    expect(validate('/api/zapper/8453/swap', { ...quote, result: noTx })[0]).toContain(
+      'no tx to submit'
+    )
+  })
+
+  it('flags an approval-needing quote with no approvalAddress, but not an unused empty one', () => {
+    expect(
+      validate('/api/zapper/8453/swap', {
+        ...quote,
+        result: { ...quote.result, approvalNeeded: true, approvalAddress: '' },
+      })[0]
+    ).toContain('no approvalAddress')
+    expect(
+      validate('/api/zapper/8453/swap', {
+        ...quote,
+        result: { ...quote.result, approvalAddress: '' },
+      })
+    ).toEqual([])
+  })
+
+  it('flags drifted shapes', () => {
+    // amountOut as a number instead of a wei string — precision-losing, and the
+    // widget's BigInt() would throw on a decimal.
+    expect(
+      validate('/api/zapper/8453/swap', {
+        ...quote,
+        result: { ...quote.result, amountOut: 17.9 },
+      })[0]
+    ).toContain('shape drifted')
+    expect(validate('/api/zapper/8453/swap', 'not json at all')[0]).toContain('non-JSON')
+  })
+
+  it('accepts documented error statuses but not unexpected ones', () => {
+    expect(
+      validate(
+        '/api/zapper/8453/swap',
+        { status: 'error', error: 'no route' },
+        { status: 500 }
+      )
+    ).toEqual([])
+    expect(validate('/api/zapper/8453/swap', {}, { status: 404 })[0]).toContain('HTTP 404')
+  })
+
+  it('validates the planner price envelope, deploy zaps and token lists', () => {
+    expect(
+      validate('/api/prices/8453', {
+        status: 'success',
+        result: [{ address: '0x4200000000000000000000000000000000000006', symbol: 'WETH', price: 1861.9 }],
+      })
+    ).toEqual([])
+    expect(
+      validate('/api/prices/8453', {
+        status: 'success',
+        result: [{ address: '0x4200000000000000000000000000000000000006', symbol: 'WETH', price: '1861.9' }],
+      })[0]
+    ).toContain('shape drifted')
+    expect(
+      validate('/api/zapper/8453/deploy-ungoverned', quote, { method: 'POST' })
+    ).toEqual([])
+    // Both element shapes in the wild: flat (zrs1) and { token, liquidity }
+    // (api.reserve.org).
+    const token = {
+      address: '0x4200000000000000000000000000000000000006',
+      symbol: 'WETH',
+      name: 'Wrapped Ether',
+      decimals: 18,
+    }
+    expect(validate('/api/zapper/1/tokens', { status: 'success', result: [token] })).toEqual([])
+    expect(
+      validate('/api/zapper/8453/tokens', {
+        status: 'success',
+        result: [{ token, liquidity: 99645.0 }],
+      })
+    ).toEqual([])
+  })
+
+  it('validates the reserve pricing and compliance surfaces', () => {
+    const reserve = { surface: 'reserve' as const }
+    expect(
+      validate(
+        '/current/prices',
+        [{ address: '0x4200000000000000000000000000000000000006', price: 1863.1, timestamp: 1 }],
+        reserve
+      )
+    ).toEqual([])
+    // A price the app would render as NaN.
+    expect(
+      validate(
+        '/current/prices',
+        [{ address: '0x4200000000000000000000000000000000000006', price: '1863.1' }],
+        reserve
+      )[0]
+    ).toContain('shape drifted')
+    expect(validate('/current/dtf', { price: 5.21 }, reserve)).toEqual([])
+    expect(
+      validate('/historical/dtf', { timeseries: [{ timestamp: 1, price: 5.2 }] }, reserve)
+    ).toEqual([])
+    // use-dtf-restricted fail-closes on a non-boolean `restricted`.
+    expect(
+      validate(
+        '/v2/compliance/geolocation/dtf/0x4dA9A0f397dB1397902070f93a4D6ddBC0E0E6e8',
+        { restricted: 'false' },
+        reserve
+      )[0]
+    ).toContain('shape drifted')
+  })
+
+  it('ignores endpoints that have no contract', () => {
+    expect(validate('/some/unknown/endpoint', { anything: true })).toEqual([])
+  })
+})
+
+// The pinned-chain-state vs live-API join. A basket token the mocked chain has
+// never seen makes the DTF header unrenderable, so the drift must be detected
+// (case-insensitively) rather than surfacing as a UI timeout.
+describe('basket drift between the snapshot and the live API', () => {
+  const weth = '0x4200000000000000000000000000000000000006'
+  const shib = '0x2859e4544C4bB03966803b044A93563Bd2D0DD4D'
+
+  it('reports no drift for the same basket in different casings', () => {
+    const drift = basketDrift(
+      { basket: [{ address: weth.toUpperCase() }] },
+      { basket: [{ address: weth }] }
+    )
+    expect(describeBasketDrift(drift)).toEqual([])
+  })
+
+  it('reports tokens the live API added and the snapshot lost', () => {
+    const drift = basketDrift(
+      { basket: [{ address: weth }] },
+      { basket: [{ address: shib }] }
+    )
+    expect(drift.added).toEqual([shib.toLowerCase()])
+    expect(drift.removed).toEqual([weth])
+    expect(describeBasketDrift(drift)).toEqual([
+      `+${shib.toLowerCase()}`,
+      `-${weth}`,
+    ])
+  })
+
+  it('separates a teardown race from a real live-request failure', () => {
+    expect(
+      isTeardownRace('route.fetch: Target page, context or browser has been closed')
+    ).toBe(true)
+    expect(isTeardownRace('apiResponse.text: Response has been disposed')).toBe(true)
+    expect(isTeardownRace('apiRequestContext.get: socket hang up')).toBe(false)
+    expect(isTeardownRace('route.fetch: Timeout 60000ms exceeded')).toBe(false)
+  })
+
+  it('treats a missing or malformed basket as empty rather than throwing', () => {
+    expect(describeBasketDrift(basketDrift(undefined, null))).toEqual([])
+    expect(
+      describeBasketDrift(basketDrift({ basket: 'nope' }, { basket: [null, {}] }))
+    ).toEqual([])
+  })
+})

--- a/e2e/helpers/zapper.ts
+++ b/e2e/helpers/zapper.ts
@@ -1,5 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test'
 import { encodeAbiParameters, encodeFunctionData, erc20Abi, parseUnits } from 'viem'
+import { fulfillFromLive, type LiveConfig } from './live'
 import type { UnmockedLogger } from './logger'
 import type { MockOverrides } from './overrides'
 import { findDtfByAddress, TEST_ADDRESS } from './registry'
@@ -136,6 +137,25 @@ export async function fillAmountAwaitQuote(
   }).toPass({ timeout: 90_000 })
 }
 
+// Live-mode counterpart of fillAmountAwaitQuote: the quote comes from a real
+// deployment, so there is no pinned output to expect — the oracle is "a
+// non-zero quote arrived in the read-only field". Same fill/quote retry unit
+// (balance hydration can still wipe an early fill). Returns the rendered
+// output amount.
+export async function fillAmountAwaitLiveQuote(
+  panel: Locator,
+  amount: string
+): Promise<string> {
+  const input = panel.locator('input[inputmode="decimal"]:not([disabled])')
+  const output = panel.locator('input[inputmode="decimal"][disabled]')
+  await expect(async () => {
+    await input.fill(amount)
+    // Anything but empty/zero — a live quote's magnitude is not predictable.
+    await expect(output).toHaveValue(/^(?!0(\.0*)?$)\d*\.?\d+$/, { timeout: 30_000 })
+  }).toPass({ timeout: 150_000 })
+  return (await output.inputValue()) ?? ''
+}
+
 const AGGREGATORS = ['velora', 'enso'] as const
 
 // Logger the zap specs hand to mockZapperRoutes: mirrors the base fixture's
@@ -161,17 +181,41 @@ function matches(params: ZapQuoteParams, query: URLSearchParams): boolean {
 // Install the zapper mock for one DTF. `log` should push into the spec's
 // `unmockedCalls` fixture array (same contract as helpers/provider.ts) so
 // committed specs fail loudly on any quote request outside the pinned inputs.
+export interface ZapperMockOptions {
+  // Live-API mode (helpers/live.ts). With a zapper target configured, the
+  // planner endpoints (/api/zapper/**: swap quotes AND deploy zaps) are passed
+  // through to the real deployment and validated against their contract
+  // instead of being served from pinned snapshots. The aggregator proxies
+  // follow the RESERVE surface, since that is where they live.
+  live?: LiveConfig
+  liveViolations?: string[]
+}
+
 export async function mockZapperRoutes(
   page: Page,
   dtfAddress: string,
-  log: UnmockedLogger
+  log: UnmockedLogger,
+  options: ZapperMockOptions = {}
 ) {
+  const { live, liveViolations } = options
+
+  if (live?.zapper && liveViolations) {
+    await page.route('**/api.reserve.org/api/zapper/**', (route) =>
+      fulfillFromLive(route, live.zapper!, { violations: liveViolations, log })
+    )
+  }
+
   const snapshots = ZAP_FIXTURES.filter((fixture) => {
     const dtf = findDtfByAddress(dtfAddress)
     return dtf && snapshotExists(`${dtf.snapshotDir}/zap-${fixture}.json`)
   }).map((fixture) => loadZapSnapshot(dtfAddress, fixture))
 
+  // Live mode owns the planner endpoints outright — never register the snapshot
+  // route alongside it, so no request can fall back to a pinned quote.
+  if (live?.zapper) return installAggregatorRoutes(page, live, liveViolations)
+
   // Native zap quotes: pinned-input snapshot or fail-loud 500.
+
   await page.route('**/api.reserve.org/api/zapper/**', (route) => {
     const url = new URL(route.request().url())
     if (!url.pathname.endsWith('/swap')) {
@@ -203,11 +247,43 @@ export async function mockZapperRoutes(
     })
   })
 
-  // Aggregator quotes: deterministic provider error (NOT unmocked — this is the
-  // designed single-provider setup, see header comment).
-  for (const slug of AGGREGATORS) {
-    await page.route(`**/api.reserve.org/${slug}/swap**`, (route) =>
+  await installAggregatorRoutes(page, live, liveViolations)
+}
+
+// Aggregator quotes: deterministic provider error (NOT unmocked — this is the
+// designed single-provider setup, see header comment). In live mode they are
+// only passed through when the RESERVE surface is live, because that is the
+// deployment that proxies them; with only the zapper surface live they stay
+// disabled, keeping the native zap the single quote candidate.
+async function installAggregatorRoutes(
+  page: Page,
+  live: LiveConfig | undefined,
+  liveViolations: string[] | undefined
+) {
+  // react-zapper also carries a CoW Swap quote source that talks to
+  // api.cow.fi DIRECTLY (not through the reserve API). It is a third-party
+  // boundary, not part of what this suite validates, and it never answers in
+  // offline mode (default-deny egress) — so in live mode it is disabled
+  // explicitly, keeping the planner quote the single candidate on both paths.
+  if (live?.reserve || live?.zapper) {
+    await page.route('**/api.cow.fi/**', (route) =>
       route.fulfill({
+        status: 503,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          errorType: 'E2E',
+          description: '[E2E] CoW disabled — the planner zap is the validated provider',
+        }),
+      })
+    )
+  }
+
+  for (const slug of AGGREGATORS) {
+    await page.route(`**/api.reserve.org/${slug}/swap**`, (route) => {
+      if (live?.reserve && liveViolations) {
+        return fulfillFromLive(route, live.reserve, { violations: liveViolations })
+      }
+      return route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
@@ -215,7 +291,7 @@ export async function mockZapperRoutes(
           error: `[E2E] ${slug} disabled — native zap is the only mocked provider`,
         }),
       })
-    )
+    })
   }
 }
 

--- a/e2e/tests/live/pricing-live.spec.ts
+++ b/e2e/tests/live/pricing-live.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '../../fixtures/base'
+import {
+  basketDrift,
+  describeBasketDrift,
+  LIVE_ENV_VARS,
+  liveConfig,
+  liveGet,
+} from '../../helpers/live'
+import { dtfPath, REGISTRY } from '../../helpers/registry'
+import { loadSnapshot } from '../../helpers/snapshots'
+
+// Pricing rendered from the LIVE reserve API (@live) — the non-quote half of the
+// validation suite.
+//
+//   E2E_LIVE_RESERVE_API=production pnpm e2e:live
+//
+// The overview header price and the price chart are the two surfaces that turn
+// /current/dtf + /historical/dtf into pixels. The request-level contract spec
+// proves the payload's shape; this proves register RENDERS it — a schema-valid
+// response that leaves the header on its skeleton, or a timeseries the chart
+// cannot plot, fails here only.
+//
+// Values are NOT asserted (live prices move); the oracle is "a price was
+// rendered in the app's own money format, and the chart has a plotted path".
+// RPC/subgraph stay mocked, so the DTF identity and basket are the deterministic
+// ones from the snapshots while every price comes from the deployment.
+
+test.describe.configure({ timeout: 120_000 })
+
+const config = liveConfig()
+
+test.describe('@live pricing surfaces against the live reserve API', () => {
+  test.skip(
+    !config.reserve,
+    `set ${LIVE_ENV_VARS.reserve} (e.g. production) to run the live pricing flow`
+  )
+
+  for (const dtf of REGISTRY.filter((entry) => !entry.deprecated)) {
+    test(`overview renders a live price for ${dtf.slug} (${dtf.chain})`, async ({
+      page,
+      request,
+      unmockedCalls,
+      liveViolations,
+      boundaryRequests,
+    }) => {
+      // Precondition, not a product assertion: the SDK joins the API basket with
+      // the (mocked, pinned) chain state by address, so a basket that moved since
+      // the last capture can never render. Say so explicitly.
+      const { data } = await liveGet(
+        request,
+        config.reserve!,
+        `/current/dtf?address=${dtf.address.toLowerCase()}&chainId=${dtf.chainId}`,
+        liveViolations
+      )
+      const drift = describeBasketDrift(
+        basketDrift(loadSnapshot(`${dtf.snapshotDir}/current-price.json`), data)
+      )
+      test.skip(
+        drift.length > 0,
+        `${dtf.slug}: live basket ${drift.join(' ')} vs the pinned chain-state ` +
+          `snapshot — the SDK cannot join them, run \`pnpm e2e:capture\` to ` +
+          `validate this DTF's pricing UI (docs/wiki/progress.md § E2E coverage debt)`
+      )
+
+      await page.goto(dtfPath(dtf, 'overview'))
+
+      // Header price: skeleton -> value. `$0` would mean the response landed but
+      // carried no usable price, so the money format is asserted, not just text.
+      const price = page.getByTestId('overview-dtf-price')
+      await expect(price).toHaveText(/^\$[\d,]+(\.\d+)?$/, { timeout: 60_000 })
+      await expect(price).not.toHaveText(/^\$0(\.0+)?$/)
+
+      // Chart: plotted geometry, not just the container — proves the live
+      // series was consumed and is plottable. The default chart type is
+      // candlestick (recharts bars); the line type draws an area curve.
+      const chart = page.getByTestId('overview-price-chart')
+      await expect(chart.locator('svg').first()).toBeVisible({ timeout: 60_000 })
+      const plotted = chart.locator(
+        'svg .recharts-bar-rectangle, svg .recharts-area-curve'
+      )
+      await expect
+        .poll(() => plotted.count(), { timeout: 60_000, message: 'chart plotted nothing' })
+        .toBeGreaterThan(0)
+
+      // The price came from the live API, with the identity register is
+      // expected to send.
+      const priceRequests = boundaryRequests.filter(
+        (entry) => entry.boundary === 'api' && entry.pathname.includes('/current/dtf')
+      )
+      expect(priceRequests.length, 'no /current/dtf request recorded').toBeGreaterThan(0)
+      expect(
+        priceRequests.some(
+          (entry) =>
+            entry.boundary === 'api' &&
+            entry.search.address?.toLowerCase() === dtf.address.toLowerCase()
+        ),
+        '/current/dtf must be requested for this DTF address'
+      ).toBe(true)
+
+      expect(unmockedCalls).toEqual([])
+    })
+  }
+})

--- a/e2e/tests/live/reserve-api-contract.spec.ts
+++ b/e2e/tests/live/reserve-api-contract.spec.ts
@@ -1,0 +1,194 @@
+import { expect, test } from '@playwright/test'
+import {
+  LIVE_ENV_VARS,
+  liveConfig,
+  liveGet,
+  type LiveTarget,
+} from '../../helpers/live'
+import { CHAINS, REGISTRY, TEST_ADDRESS } from '../../helpers/registry'
+import { loadSnapshot } from '../../helpers/snapshots'
+
+// Live Reserve-API contract validation (@live) — request-level, no browser.
+//
+// Every request here is byte-for-byte the request register's own hooks build
+// (the comment on each test names the consumer), issued against the target in
+// E2E_LIVE_RESERVE_API. The oracle is the endpoint contract in
+// helpers/live-contracts.ts plus request-correlated invariants a schema cannot
+// express — e.g. "every token I asked to price came back priced", which is what
+// actually breaks the deploy basket and the overview.
+//
+//   E2E_LIVE_RESERVE_API=production pnpm e2e:live
+//
+// Skips (not fails) when the reserve surface names no target: an offline
+// checkout must never be able to "pass" this file by accident.
+
+const config = liveConfig()
+const target = config.reserve
+
+// Basket tokens per chain, from the captured chain state — snapshot-derived
+// identities (never hardcoded addresses), which is what the price endpoints are
+// asked about in production.
+function basketTokens(snapshotDir: string): string[] {
+  const state = loadSnapshot<{ basketTokens: Array<{ address: string }> }>(
+    `${snapshotDir}/chain-state.json`
+  )
+  return state.basketTokens.map((token) => token.address)
+}
+
+test.describe('@live reserve API contract', () => {
+  test.skip(
+    !target,
+    `set ${LIVE_ENV_VARS.reserve} (e.g. production) to validate the live reserve API`
+  )
+
+  const reserve = target as LiveTarget
+  const violations: string[] = []
+
+  test.afterEach(() => {
+    expect(violations, violations.join('\n')).toEqual([])
+    violations.length = 0
+  })
+
+  for (const dtf of REGISTRY.filter((entry) => !entry.deprecated)) {
+    // hooks/usePrices.ts + views/index-dtf/deploy/updater.tsx — the deploy
+    // wizard prices its whole basket in ONE batch and renders $0 for any token
+    // the response omits, so a partial answer is a product bug, not a nicety.
+    test(`current prices for the ${dtf.slug} basket (${dtf.chain})`, async ({ request }) => {
+      const tokens = basketTokens(dtf.snapshotDir)
+      expect(tokens.length).toBeGreaterThan(0)
+
+      const { status, data } = await liveGet(
+        request,
+        reserve,
+        `/current/prices?tokens=${tokens.join(',')}&chainId=${dtf.chainId}`,
+        violations
+      )
+      expect(status).toBe(200)
+
+      const priced = new Map(
+        (data as Array<{ address: string; price?: number | null }>).map((entry) => [
+          entry.address.toLowerCase(),
+          entry.price,
+        ])
+      )
+      const missing = tokens.filter((token) => !priced.has(token.toLowerCase()))
+      expect(missing, `unpriced basket tokens on chain ${dtf.chainId}`).toEqual([])
+      for (const token of tokens) {
+        expect(priced.get(token.toLowerCase()), `price for ${token}`).toBeGreaterThan(0)
+      }
+    })
+
+    // hooks/useIndexPrice.ts (overview header, portfolio rows).
+    test(`current dtf price for ${dtf.slug} (${dtf.chain})`, async ({ request }) => {
+      const { status, data } = await liveGet(
+        request,
+        reserve,
+        `/current/dtf?address=${dtf.address}&chainId=${dtf.chainId}`,
+        violations
+      )
+      expect(status).toBe(200)
+      expect((data as { price?: number }).price).toBeGreaterThan(0)
+    })
+
+    // views/index-dtf/overview price chart — an empty series renders a blank
+    // chart, which is why the series length is asserted, not just the shape.
+    test(`historical dtf series for ${dtf.slug} (${dtf.chain})`, async ({ request }) => {
+      const to = Math.floor(Date.now() / 1000)
+      const from = to - 7 * 24 * 60 * 60
+      const { status, data } = await liveGet(
+        request,
+        reserve,
+        `/historical/dtf?address=${dtf.address}&chainId=${dtf.chainId}&from=${from}&to=${to}&interval=1h`,
+        violations
+      )
+      expect(status).toBe(200)
+      const series = (data as { timeseries: Array<{ timestamp: number }> }).timeseries
+      expect(series.length).toBeGreaterThan(0)
+      const timestamps = series.map((point) => point.timestamp)
+      expect(timestamps, 'timeseries must be ascending').toEqual([...timestamps].sort((a, b) => a - b))
+    })
+
+    // hooks/use-dtf-restricted.ts fail-CLOSES on an unexpected shape: drift here
+    // gates issuance/governance for every user, so the live shape is contracted.
+    test(`dtf compliance for ${dtf.slug} (${dtf.chain})`, async ({ request }) => {
+      const { status, data } = await liveGet(
+        request,
+        reserve,
+        `/v2/compliance/geolocation/dtf/${dtf.address}?chainId=${dtf.chainId}`,
+        violations
+      )
+      expect(status).toBe(200)
+      expect(typeof (data as { restricted: unknown }).restricted).toBe('boolean')
+    })
+  }
+
+  // hooks/use-asset-prices-with-snapshot.ts / useSimulatedBasket.ts.
+  test('historical asset prices', async ({ request }) => {
+    const dtf = REGISTRY.find((entry) => entry.chain === 'base' && !entry.deprecated)!
+    const [token] = basketTokens(dtf.snapshotDir)
+    const to = Math.floor(Date.now() / 1000)
+    const { status, data } = await liveGet(
+      request,
+      reserve,
+      `/historical/prices?address=${token}&chainId=${dtf.chainId}&from=${to - 86_400}&to=${to}&interval=1h`,
+      violations
+    )
+    expect(status).toBe(200)
+    expect((data as { timeseries: unknown[] }).timeseries.length).toBeGreaterThan(0)
+  })
+
+  // hooks/use-geolocation.ts (app-wide gate) and use-wallet-compliance.ts.
+  test('compliance surfaces', async ({ request }) => {
+    const geo = await liveGet(request, reserve, '/v2/compliance/geolocation', violations)
+    expect(geo.status).toBe(200)
+    expect(typeof (geo.data as { countryCode: unknown }).countryCode).toBe('string')
+
+    const wallet = await liveGet(
+      request,
+      reserve,
+      `/v2/compliance/wallet/${TEST_ADDRESS}`,
+      violations
+    )
+    expect(wallet.status).toBe(200)
+    expect(typeof (wallet.data as { isRestricted: unknown }).isRestricted).toBe('boolean')
+  })
+
+  // views/home discover lists — every registry chain must be discoverable, or
+  // the home page silently drops a chain.
+  test('discover dtfs', async ({ request }) => {
+    const { status, data } = await liveGet(request, reserve, '/v1/discover/dtfs', violations)
+    expect(status).toBe(200)
+    const dtfs = data as Array<{ chainId: number }>
+    expect(dtfs.length).toBeGreaterThan(0)
+    const chains = new Set(dtfs.map((entry) => entry.chainId))
+    for (const chain of Object.values(CHAINS)) {
+      expect([...chains], `discover covers chain ${chain.chainId}`).toContain(chain.chainId)
+    }
+  })
+
+  // views/portfolio-page — an unfunded address must still return the full shape
+  // (the header maps over each list unconditionally).
+  test('portfolio shape for an empty address', async ({ request }) => {
+    const { status, data } = await liveGet(
+      request,
+      reserve,
+      `/v1/portfolio/${TEST_ADDRESS}`,
+      violations
+    )
+    expect(status).toBe(200)
+    expect(Array.isArray((data as { indexDTFs: unknown }).indexDTFs)).toBe(true)
+  })
+
+  // views/index-dtf/auctions asset-volatility inputs (an object here crashes
+  // tokens.map and takes the rebalance view down through its error boundary).
+  test('zappable token list', async ({ request }) => {
+    const { status, data } = await liveGet(
+      request,
+      reserve,
+      `/zapper/tokens?chainId=${CHAINS.base.chainId}`,
+      violations
+    )
+    expect(status).toBe(200)
+    expect(Array.isArray(data)).toBe(true)
+  })
+})

--- a/e2e/tests/live/zap-widget-live.spec.ts
+++ b/e2e/tests/live/zap-widget-live.spec.ts
@@ -1,0 +1,104 @@
+import { connectWallet, expect, test } from '../../fixtures/wallet'
+import { LIVE_ENV_VARS, liveConfig } from '../../helpers/live'
+import { dtfPath, findDtfByAddress } from '../../helpers/registry'
+import {
+  fillAmountAwaitLiveQuote,
+  mockZapperRoutes,
+  seedZapSurface,
+  zapUnmockedLogger,
+} from '../../helpers/zapper'
+
+// End-to-end zap through the REAL planner (@live): the same widget flow as
+// tests/flows/zap-buy-sell.spec.ts, but the quote is fetched from the live
+// deployment instead of a pinned snapshot.
+//
+//   E2E_LIVE_ZAPPER_API=zrs1 pnpm e2e:live
+//
+// What this adds over the request-level contract spec: it proves the widget can
+// PARSE and USE what the deployment returns — a quote that satisfies the schema
+// but, say, renders as an empty output field or produces calldata the widget
+// never submits fails here and passes there.
+//
+// Still mocked, deliberately: RPC/subgraph/wallet. Chain state (balances,
+// receipts) stays deterministic and no real transaction is ever broadcast — the
+// mock provider swallows the live calldata and hands back a receipt, so the
+// assertion is "the widget submitted exactly the live quote's tx".
+
+test.describe.configure({ mode: 'serial', timeout: 180_000 })
+
+const DTF_ADDRESS = '0x4dA9A0f397dB1397902070f93a4D6ddBC0E0E6e8' // base/lcap
+const AMOUNT = '0.05' // ETH in; same trade the offline suite pins
+
+const config = liveConfig()
+
+test.describe('@live zap widget against the live planner', () => {
+  test.skip(
+    !config.zapper,
+    `set ${LIVE_ENV_VARS.zapper}=zrs1 to run the live zap flow`
+  )
+
+  test('buy LCAP with ETH using a live quote', async ({
+    page,
+    overrides,
+    unmockedCalls,
+    txLog,
+    live,
+    liveViolations,
+  }) => {
+    // Every live /api/zapper/**/swap response the widget received, in order.
+    // The submitted tx must be one of these — the widget refetches every ~9s,
+    // so the last-observed quote is not necessarily the one that was armed.
+    const quotes: Array<{ to: string; data: string; value: string }> = []
+    page.on('response', async (response) => {
+      const url = response.url()
+      if (!url.includes('/api/zapper/') || !url.includes('/swap')) return
+      const body = await response.text().catch(() => '')
+      if (!body) return
+      const parsed = JSON.parse(body) as {
+        result?: { tx?: { to: string; data: string; value: string } | null }
+      }
+      if (parsed.result?.tx) quotes.push(parsed.result.tx)
+    })
+
+    seedZapSurface(overrides, DTF_ADDRESS)
+    await mockZapperRoutes(page, DTF_ADDRESS, zapUnmockedLogger(unmockedCalls), {
+      live,
+      liveViolations,
+    })
+
+    const dtf = findDtfByAddress(DTF_ADDRESS)!
+    await page.goto(dtfPath(dtf, 'issuance'))
+    await connectWallet(page)
+
+    const panel = page
+      .getByTestId('issuance-zap-widget')
+      .locator('div[role="tabpanel"][data-state="active"]')
+    await expect(panel).toBeVisible({ timeout: 30_000 })
+    await expect(panel.locator('button[aria-haspopup="menu"]')).toContainText('ETH')
+
+    const quoted = await fillAmountAwaitLiveQuote(panel, AMOUNT)
+    expect(Number(quoted), 'live quote output').toBeGreaterThan(0)
+    expect(quotes.length, 'live planner returned an executable quote').toBeGreaterThan(0)
+
+    const submit = panel.locator('button').last()
+    await expect(submit).toBeEnabled({ timeout: 30_000 })
+    await submit.click()
+
+    const widget = page.getByTestId('issuance-zap-widget')
+    const txLink = widget.locator('a[href*="/tx/0x"]')
+    await expect(txLink).toBeVisible({ timeout: 30_000 })
+
+    // The widget submitted the planner's own calldata, unmodified.
+    expect(txLog).toHaveLength(1)
+    expect(txLog[0].chainId).toBe(dtf.chainId)
+    const submitted = quotes.find(
+      (tx) =>
+        tx.to.toLowerCase() === txLog[0].to &&
+        tx.data.toLowerCase() === txLog[0].data.toLowerCase()
+    )
+    expect(submitted, 'submitted tx must match a live quote').toBeDefined()
+    expect(BigInt(txLog[0].value)).toBe(BigInt(submitted!.value))
+
+    expect(unmockedCalls).toEqual([])
+  })
+})

--- a/e2e/tests/live/zapper-api-contract.spec.ts
+++ b/e2e/tests/live/zapper-api-contract.spec.ts
@@ -1,0 +1,255 @@
+import { expect, test } from '@playwright/test'
+import { PriceControl } from '@reserve-protocol/dtf-rebalance-lib'
+import { parseEther, parseUnits, type Address } from 'viem'
+import {
+  LIVE_ENV_VARS,
+  liveConfig,
+  liveGet,
+  livePost,
+  liveProbe,
+  type LiveTarget,
+} from '../../helpers/live'
+import { CHAINS, REGISTRY, TEST_ADDRESS, type ChainKey } from '../../helpers/registry'
+import { loadSnapshot } from '../../helpers/snapshots'
+import { loadZapSnapshot } from '../../helpers/zapper'
+
+// Live zapper-API contract validation (@live) — request-level, no browser.
+//
+// Target is E2E_LIVE_ZAPPER_API; `zrs1` (https://zrs-1.reserve-api.com) is a
+// planner deployment, so it owns the whole surface register's zap and deploy
+// flows use:
+//
+//   GET  /api/zapper/{chainId}/swap              — buy/sell quotes (useZapSwapQuery)
+//   POST /api/zapper/{chainId}/deploy[-ungoverned] — deploy zaps (useZapDeployQuery)
+//   GET  /api/zapper/{chainId}/tokens            — zappable list (utils/zapper.ts)
+//   GET  /api/prices/{chainId}                   — the planner's own token
+//                                                  pricing (one source behind
+//                                                  reserve-api /current/prices)
+//
+//   E2E_LIVE_ZAPPER_API=zrs1 pnpm e2e:live
+//
+// Requests mirror what register builds (zapV2/api/index.ts for the URLs,
+// deploy/steps/confirm-deploy/simple/atoms.ts for the deploy body). Responses
+// are validated against helpers/live-contracts.ts — shape plus the executability
+// invariants (amountOut > 0, a tx to submit, a floor the tx can actually meet).
+
+const NATIVE = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+
+// Probe input per chain — a live quote needs a plausible amount, and these are
+// INPUTS, not expected values (nothing is asserted against them). Base uses the
+// captured buy fixture's pinned amount so the mocked and live suites quote the
+// same trade; the others are the same order of magnitude in native token.
+const PROBE_AMOUNT: Record<ChainKey, string> = {
+  base: loadZapSnapshot(
+    REGISTRY.find((entry) => entry.chain === 'base' && entry.slug === 'lcap')!.address,
+    'buy'
+  ).params.amountIn,
+  mainnet: parseEther('0.05').toString(),
+  bsc: parseEther('0.2').toString(),
+}
+
+const config = liveConfig()
+const target = config.zapper
+
+test.describe('@live zapper API contract', () => {
+  test.skip(
+    !target,
+    `set ${LIVE_ENV_VARS.zapper}=zrs1 to validate the live zapper API`
+  )
+
+  const zapper = target as LiveTarget
+  const violations: string[] = []
+
+  test.afterEach(() => {
+    expect(violations, violations.join('\n')).toEqual([])
+    violations.length = 0
+  })
+
+  test('planner is healthy', async ({ request }) => {
+    const { status } = await liveGet(request, zapper, '/health', violations)
+    expect(status).toBe(200)
+  })
+
+  for (const chain of Object.values(CHAINS)) {
+    // Zappable token list (utils/zapper.ts fetchZapperTokens; the rebalance
+    // "manage weights" and proposal liquidity-check gates read it).
+    //
+    // PROBED, NOT PARSED: this response is not a small document. On zrs1 the
+    // Base list streams ~500 MB (production's is ~700 KB), so buffering it
+    // would dominate the run and tell us nothing extra — the head of the stream
+    // is enough to see the envelope the client has to consume.
+    test(`zappable token list on ${chain.key}`, async () => {
+      const { status, head, bytes } = await liveProbe(
+        zapper,
+        `/api/zapper/${chain.chainId}/tokens`
+      )
+      expect(status).toBe(200)
+      expect(bytes, 'token list is empty').toBeGreaterThan(0)
+
+      // The envelope must be the planner's `{ status: "success", result: [...] }`
+      // with address-bearing entries. Asserted on the head so a switch to a bare
+      // array (or an error envelope) fails here.
+      expect(head.startsWith('{"status":"success"'), `envelope: ${head.slice(0, 80)}`).toBe(
+        true
+      )
+      expect(head).toContain('"result":[')
+      expect(head).toMatch(/"address":"0x[a-fA-F0-9]{40}"/)
+    })
+  }
+
+  // KNOWN DRIFT, pinned deliberately: fetchZapperTokens reads `data.tokens[]`,
+  // but every deployment answers `{ status, result: [...] }`. The catch-all in
+  // that helper turns the mismatch into an empty Set, i.e. "no token is
+  // zappable" — silently, with no error surfaced. Marked `fail` so the suite
+  // stays honest about it: when the client (or the API) is fixed, this test goes
+  // green-on-a-fail-expectation and forces the pin to be removed.
+  test('fetchZapperTokens can read the live token list', async () => {
+    test.fail()
+    const { head } = await liveProbe(zapper, `/api/zapper/${CHAINS.base.chainId}/tokens`)
+    expect(head, 'response has no `tokens` key for fetchZapperTokens to read').toContain(
+      '"tokens":['
+    )
+  })
+
+  for (const dtf of REGISTRY.filter((entry) => !entry.deprecated)) {
+    // Upstream pricing for a real basket. The planner's price service is one of
+    // the sources behind reserve-api's /current/prices (`priceSources`), not the
+    // whole of it — register reads /current/prices, so a planner gap only
+    // reaches the UI as $0 when no other source covers the token either. Both
+    // halves are asserted: the planner's own contract, and the guarantee that
+    // whatever it cannot price the reserve API still can.
+    test(`planner prices the ${dtf.slug} basket (${dtf.chain})`, async ({ request }) => {
+      const state = loadSnapshot<{ basketTokens: Array<{ address: string }> }>(
+        `${dtf.snapshotDir}/chain-state.json`
+      )
+      const tokens = state.basketTokens.map((token) => token.address)
+      expect(tokens.length).toBeGreaterThan(0)
+
+      const { status, data } = await liveGet(
+        request,
+        zapper,
+        `/api/prices/${dtf.chainId}?tokens=${tokens.join(',')}`,
+        violations
+      )
+      expect(status).toBe(200)
+
+      const priced = new Map(
+        ((data as { result?: Array<{ address: string; price: number }> }).result ?? []).map(
+          (entry) => [entry.address.toLowerCase(), entry.price]
+        )
+      )
+      for (const [address, price] of priced) {
+        expect(price, `planner price for ${address}`).toBeGreaterThan(0)
+      }
+
+      // Tokens the planner has no source for (PHOTON's Ondo RWA tokens on BSC,
+      // for one) must still be priced by the endpoint register actually reads,
+      // or the basket renders at $0.
+      const missing = tokens.filter((token) => !priced.has(token.toLowerCase()))
+      test.skip(
+        missing.length > 0 && !config.reserve,
+        `planner priced none of ${missing.join(', ')} — set ${LIVE_ENV_VARS.reserve} ` +
+          'to check the reserve API covers them'
+      )
+      if (missing.length === 0) return
+
+      const { data: reservePrices } = await liveGet(
+        request,
+        config.reserve!,
+        `/current/prices?chainId=${dtf.chainId}&tokens=${missing.join(',')}`,
+        violations
+      )
+      const covered = new Set(
+        (reservePrices as Array<{ address: string; price?: number }>)
+          .filter((entry) => (entry.price ?? 0) > 0)
+          .map((entry) => entry.address.toLowerCase())
+      )
+      expect(
+        missing.filter((token) => !covered.has(token.toLowerCase())),
+        `tokens no live price source covers on ${dtf.chain} (planner gap AND reserve gap)`
+      ).toEqual([])
+    })
+
+    // useZapSwapQuery's exact request (zapper.zap in zapV2/api/index.ts): buy
+    // the DTF with the chain's native token. The signer is the unfunded test
+    // wallet, so `insufficientFunds` may be true — the planner still constructs
+    // the route, which is what the contract covers. Executability invariants
+    // (amountOut > 0, tx present, minAmountOut <= amountOut) come from
+    // live-contracts.ts and surface as violations.
+    test(`buy quote for ${dtf.slug} (${dtf.chain})`, async ({ request }) => {
+      const amountIn = PROBE_AMOUNT[dtf.chain]
+      const query = new URLSearchParams({
+        chainId: String(dtf.chainId),
+        signer: TEST_ADDRESS,
+        tokenIn: NATIVE,
+        amountIn,
+        tokenOut: dtf.address,
+        slippage: '100',
+        trade: 'true',
+        bypassCache: 'true',
+      })
+      const { status, data } = await liveGet(
+        request,
+        zapper,
+        `/api/zapper/${dtf.chainId}/swap?${query.toString()}`,
+        violations
+      )
+      expect(status, `quote HTTP status (${dtf.slug})`).toBe(200)
+      const quote = data as { status: string; result?: { amountOut: string } }
+      expect(quote.status, `quote status (${dtf.slug})`).toBe('success')
+      expect(BigInt(quote.result!.amountOut)).toBeGreaterThan(0n)
+    })
+  }
+
+  // useZapDeployQuery's request (deploy wizard → confirm-deploy → simple):
+  // the DEPLOY half of the coverage. Body shape comes from
+  // ZapDeployUngovernedBody; the basket is a real, priced two-token basket on
+  // Base so the planner has to actually route and encode a deploy.
+  test('ungoverned deploy zap quote (base)', async ({ request }) => {
+    const chainId = CHAINS.base.chainId
+    const weth = '0x4200000000000000000000000000000000000006' as Address
+    const usdc = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as Address
+
+    const payload = {
+      tokenIn: NATIVE as Address,
+      amountIn: parseEther('0.05').toString(),
+      signer: TEST_ADDRESS as Address,
+      slippage: 0.01,
+      owner: TEST_ADDRESS as Address,
+      basicDetails: {
+        assets: [weth, usdc],
+        // Per 1 share of output, mirroring basketRequiredAmountsAtom.
+        amounts: [parseUnits('0.0002', 18).toString(), parseUnits('0.5', 6).toString()],
+        name: 'E2E Live Validation DTF',
+        symbol: 'E2ELV',
+      },
+      additionalDetails: {
+        auctionLength: '1800',
+        feeRecipients: [{ recipient: TEST_ADDRESS as Address, portion: parseEther('1').toString() }],
+        tvlFee: parseEther('0.01').toString(),
+        mintFee: parseEther('0.0005').toString(),
+        mandate: 'e2e live validation',
+      },
+      folioFlags: {
+        trustedFillerEnabled: true,
+        rebalanceControl: { weightControl: false, priceControl: PriceControl.PARTIAL },
+        bidsEnabled: false,
+      },
+      basketManagers: [] as Address[],
+      auctionLaunchers: [] as Address[],
+      brandManagers: [] as Address[],
+    }
+
+    const { status, data } = await livePost(
+      request,
+      zapper,
+      `/api/zapper/${chainId}/deploy-ungoverned?chainId=${chainId}`,
+      payload,
+      violations
+    )
+    expect(status, 'deploy-zap HTTP status').toBe(200)
+    const quote = data as { status: string; result?: { amountOut: string; tx: unknown } }
+    expect(quote.status, 'deploy-zap status').toBe('success')
+    expect(BigInt(quote.result!.amountOut)).toBeGreaterThan(0n)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "e2e": "playwright test",
     "e2e:smoke": "playwright test --project=smoke",
     "e2e:mobile": "playwright test --project=mobile",
+    "e2e:live": "playwright test --project=live",
     "e2e:ui": "playwright test --ui",
     "e2e:capture": "tsx e2e/scripts/capture.ts",
     "e2e:capture:yield": "tsx e2e/scripts/capture-yield.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,11 +37,12 @@ export default defineConfig({
     {
       name: 'smoke',
       grep: /@smoke/,
+      grepInvert: /@live/,
       use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'full',
-      grepInvert: /@smoke/,
+      grepInvert: /@smoke|@live/,
       use: { ...devices['Desktop Chrome'] },
     },
     // Mobile variants at a phone viewport. Pixel 7 keeps the Chromium engine
@@ -50,7 +51,24 @@ export default defineConfig({
     {
       name: 'mobile',
       grep: /@mobile/,
+      grepInvert: /@live/,
       use: { ...devices['Pixel 7'] },
+    },
+    // Live-API validation project (`pnpm e2e:live`). @live specs are EXCLUDED
+    // from every other project: they need a real Reserve/zapper deployment and
+    // skip themselves when E2E_LIVE_RESERVE_API / E2E_LIVE_ZAPPER_API name no
+    // target (see e2e/helpers/live.ts). Live upstreams are slow (a cold token
+    // list or deep-liquidity quote can take tens of seconds) and their data is
+    // not deterministic — so: generous timeout, no retries (a retry would mask
+    // an intermittently-broken deployment, which is exactly the signal here),
+    // and serial workers so one run cannot rate-limit itself.
+    {
+      name: 'live',
+      grep: /@live/,
+      timeout: 180_000,
+      retries: 0,
+      workers: 1,
+      use: { ...devices['Desktop Chrome'] },
     },
   ],
   webServer: {


### PR DESCRIPTION
## Summary

The e2e suite had no way to hit the real APIs: `fixtures/base.ts` default-denies egress and always serves the Reserve/zapper boundaries from snapshots (`allowUnmocked` only silences the teardown failure — the mocks still answer). This adds a **separate, opt-in `live` project** so the same specs can be used as a validation suite for Register's *usage* of the Reserve and zapper/planner APIs, against `zrs1` in particular. The offline suites are untouched and stay deterministic.

Two independent surfaces, one classifier:

```ts
// helpers/live.ts
LIVE_TARGETS = { zrs1: 'https://zrs-1.reserve-api.com', production: 'https://api.reserve.org', staging: … }
LIVE_ENV_VARS = { reserve: 'E2E_LIVE_RESERVE_API', zapper: 'E2E_LIVE_ZAPPER_API' }
surfaceForPath(p) = p.startsWith('/api/zapper/') || p.startsWith('/api/prices/') ? 'zapper' : 'reserve'
resolveLiveTarget(surface, value)   // named target | absolute URL | throws (never a silent offline fallback)
```

```bash
E2E_LIVE_RESERVE_API=production E2E_LIVE_ZAPPER_API=zrs1 pnpm e2e:live
```

Live mode is a **boundary swap, not an escape hatch** — `helpers/api.ts` consults the live target before snapshots/overrides, and default-deny egress, `boundaryRequests` recording and strict teardown all still apply:

```ts
const liveTarget = live?.[surfaceForPath(path)]
if (liveTarget && liveViolations)
  return fulfillFromLive(route, liveTarget, { violations: liveViolations, log, requests })
```

Live responses are additionally checked by `helpers/live-contracts.ts` (per-endpoint zod shape + invariants — quote `minAmountOut <= amountOut`, non-zero `amountOut`, a `tx` whenever funds suffice, candle `high >= low` with open/close in range). Drift or a broken invariant fails the test.

Coverage in `e2e/tests/live/`: request-level contracts for the Reserve API (prices, current/historical DTF + v2 candles, compliance, discover, portfolio, exposure, rebalance, `POST /rebalance/liquidity`) and the planner (health, bounded token-list probe, `/api/prices/{chain}`, buy quotes, ungoverned deploy quote), plus UI specs driving live pricing and the zap widget (live quote in, submitted tx compared to the quote's `tx`).

Non-obvious bits found while running it against zrs1/production, all documented in `docs/wiki/progress.md` § E2E coverage debt and `e2e/README.md` § Live API mode:

- `/api/zapper/{chain}/tokens` is ~500 MB → `liveProbe` validates a bounded prefix, never buffers.
- **`fetchZapperTokens` cannot read any deployment's token list**: it reads `data.tokens[]`, deployments answer `{status, result[]}`, and its `catch` turns that into an empty Set — "nothing is zappable", silently. Pinned with `test.fail()` rather than hidden; needs a client-or-API decision.
- The planner prices none of PHOTON's Ondo tokens on BSC (`/api/prices/56` → `result: []`; the route doesn't exist on api.reserve.org at all). Register reads `/current/prices`, which covers them, so the spec asserts exactly that cross-surface guarantee: a planner gap must be covered by the Reserve API, else the basket renders $0.
- Live UI specs are hybrid (live API + pinned chain state). When the live basket drifts from the capture the SDK can't join the two, so `basketDrift` detects it and the spec skips with a `pnpm e2e:capture` instruction instead of a fake pass/fail (CMC20 today: live basket added one token).
- CoW/velora/enso get an explicit disabled 503 in live mode so the planner is the provider under validation; RPC, subgraph, wallet, receipts and chain state remain mocked.

Verification: `pnpm typecheck` · `pnpm lint` · 95 helper units (23 new, `e2e/helpers/tests/live.test.ts`) · `pnpm e2e:smoke` 58 · `pnpm e2e:check` · live run against reserve=production + zapper=zrs1 → **39 passed / 1 skipped** (CMC20 basket drift).

**Engineer review required**: deploy coverage is quote-level only — the planner's deploy tx is contract-validated, never submitted on-chain — and the token-list parser drift above needs a decision on which side moves.


Link to Devin session: https://app.devin.ai/sessions/9d5a13fae07b4191b08efd0fe2040631
Requested by: @TheFrozenFire

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in live API validation mode for end-to-end testing.
  * Added coverage for Reserve pricing, history, compliance, discovery, portfolio, and zapper workflows.
  * Added live quote validation for pricing pages and zap widgets while retaining mocked blockchain interactions.
  * Added the `pnpm e2e:live` command for running live tests.

* **Documentation**
  * Documented configuration, supported targets, coverage, validation behavior, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->