### PR TITLE
fix: correct alchemy eth and bsc rpc urls

### DIFF
--- a/src/utils/rpc-urls.ts
+++ b/src/utils/rpc-urls.ts
@@ -14,7 +14,7 @@ export const registerRpcUrls = {
         'https://mainnet.gateway.tenderly.co/',
         ...(infuraKey ? [`https://mainnet.infura.io/v3/${infuraKey}`] : []),
         ...(alchemyKey
-          ? [`https://eth-mainnet.alchemyapi.io/v2/${alchemyKey}`]
+          ? [`https://eth-mainnet.g.alchemy.com/v2/${alchemyKey}`]
           : []),
         ...(ankrKey ? [`https://rpc.ankr.com/eth/${ankrKey}`] : []),
       ],
@@ -42,7 +42,7 @@ export const registerRpcUrls = {
     ...(infuraKey ? [`https://bsc-mainnet.infura.io/v3/${infuraKey}`] : []),
     ...(ankrKey ? [`https://rpc.ankr.com/bsc/${ankrKey}`] : []),
     ...(alchemyKey
-      ? [`https://bsc-mainnet.g.alchemy.com/v2/${alchemyKey}`]
+      ? [`https://bnb-mainnet.g.alchemy.com/v2/${alchemyKey}`]
       : []),
   ],
 } as const


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Ethereum mainnet and BNB Chain RPC endpoints to use the current Alchemy hostnames.
  * Improved connectivity reliability for requests using these networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->